### PR TITLE
Tag heavy feature tests and upgrade RabbitMQ to 4.3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   rabbitmq-0:
-    image: rabbitmq:3.10.0-management
+    image: rabbitmq:4.3-management
     container_name: comq-rmq-0
     ports:
       - '5673:5672'
@@ -18,7 +18,7 @@ services:
         limits:
           memory: 512MB
   rabbitmq-1:
-    image: rabbitmq:3.10.0-management
+    image: rabbitmq:4.3-management
     container_name: comq-rmq-1
     ports:
       - '5674:5672'

--- a/features/connection.feature
+++ b/features/connection.feature
@@ -1,3 +1,4 @@
+@heavy
 Feature: Connection Tolerance
 
   Scenario: Connect

--- a/features/recovery.feature
+++ b/features/recovery.feature
@@ -1,3 +1,4 @@
+@heavy
 Feature: Request-Reply Topology Recovery
 
   Background:

--- a/features/rpc.streams.feature
+++ b/features/rpc.streams.feature
@@ -64,6 +64,7 @@ Feature: Reply streams
     And after 200ms
     Then the generator is destroyed
 
+  @heavy
   Scenario: Broker crashes while streaming reply
     Given a number generator with 90ms increasing delay replying `get_numbers` queue
     When the consumer requests a stream with request to the `get_numbers` queue

--- a/features/rpc.streams.shards.feature
+++ b/features/rpc.streams.shards.feature
@@ -21,6 +21,7 @@ Feature: Reply streams over shards
       [0, 1, 2, 3, 4]
       """
 
+  @heavy
   Scenario: Broker crashes while fetching a stream
     Given a number generator with 90ms increasing delay replying `get_numbers` queue
     When the consumer requests a stream with request to the `get_numbers` queue

--- a/features/shards.feature
+++ b/features/shards.feature
@@ -1,3 +1,4 @@
+@heavy
 Feature: Sharded Connection
 
   Scenario: Establishing sharded connection

--- a/features/steps/brokers.js
+++ b/features/steps/brokers.js
@@ -8,7 +8,7 @@ const { getContainerRuntimeClient } = require('testcontainers')
 
 const docker = promisify(execFile)
 
-const IMAGE = 'rabbitmq:3.10.0-management'
+const IMAGE = 'rabbitmq:4.3-management'
 const USER = 'developer'
 const PASSWORD = 'secret'
 const AMQP_PORT = 5672

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prepare": "husky",
     "test": "standard && jest",
     "features": "cucumber-js --fail-fast -t 'not @manual'",
+    "features:fast": "cucumber-js --fail-fast -t 'not @manual and not @heavy'",
     "lint": "standard --fix --verbose | snazzy"
   },
   "standard": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Mark Gherkin features/scenarios that stop, kill, or restart broker containers with `@heavy`
- Add `npm run features:fast` to run all non-`@manual` and non-`@heavy` Cucumber tests
- Upgrade RabbitMQ image from `3.10.0-management` to `4.3-management` in Testcontainers (`features/steps/brokers.js`) and `docker-compose.yaml`

## `@heavy` coverage

| File | Tag level |
|------|-----------|
| `features/connection.feature` | Feature |
| `features/recovery.feature` | Feature |
| `features/shards.feature` | Feature |
| `features/rpc.streams.feature` | Scenario: broker crash while streaming |
| `features/rpc.streams.shards.feature` | Scenario: broker crash while fetching stream |

## Fast test timing (`npm run features:fast`, `rabbitmq:4.3-management`)

Image pre-pulled before the run (`docker pull rabbitmq:4.3-management`).

| | Result |
|--|--------|
| Scenarios | 23 passed |
| Wall clock | **45s** |
| Cucumber | 45.270s (executing steps: 37.896s) |

## Usage

```bash
npm run features:fast   # excludes @manual and @heavy
npm run features        # excludes @manual only
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0279214f-74e7-4486-811b-3aed73bc7b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0279214f-74e7-4486-811b-3aed73bc7b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

