### PR TITLE
Add GitHub workflow to run features:fast on dev pushes

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,28 @@
+name: Dev
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  features-fast:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run fast feature tests
+        run: npm run features:fast


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a GitHub Actions workflow that runs on every push to `dev` and executes `npm run features:fast` (Cucumber feature tests excluding `@manual` and `@heavy` scenarios).

The job uses the same Node.js setup as the release workflow (Node 24, `npm ci`, `HUSKY: 0`). Feature tests use Testcontainers to start RabbitMQ, which is supported on the default `ubuntu-latest` runner with Docker.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6e21a71-5517-4d89-b097-36c608be6987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6e21a71-5517-4d89-b097-36c608be6987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

