### PR TITLE
fix: skip end control when reply stream buffer overflows

### DIFF
--- a/source/.io/ReplyStream.js
+++ b/source/.io/ReplyStream.js
@@ -26,6 +26,8 @@ class ReplyStream extends Readable {
 
   #buffered = 0
 
+  #maxBufferSize
+
   /** @type {Map<number, unknown>} */
   #queue = new Map()
 
@@ -39,6 +41,7 @@ class ReplyStream extends Readable {
     this.#emitter = request.emitter
     this.#correlationId = request.properties.correlationId
     this.#idleInterval = global['COMQ_TESTING_IDLE_INTERVAL'] || IDLE_INTERVAL
+    this.#maxBufferSize = global['COMQ_TESTING_MAX_BUFFER_SIZE'] || MAX_BUFFER_SIZE
     this.#reply = reply
 
     this.#emitter.on(this.#correlationId, this.arrange.bind(this))
@@ -48,7 +51,9 @@ class ReplyStream extends Readable {
     this._clear()
     this.push(null)
 
-    void this.#reply(this.#control, control.end)
+    if (this.#control !== undefined)
+      void this.#reply(this.#control, control.end)
+
     super._destroy(error, callback)
   }
 
@@ -95,7 +100,11 @@ class ReplyStream extends Readable {
   }
 
   _buffer (payload, properties) {
-    if (this.#buffered > MAX_BUFFER_SIZE) this.destroy()
+    if (this.#buffered > this.#maxBufferSize) {
+      this.destroy()
+
+      return
+    }
 
     this.#buffered++
     this.#queue.set(properties.headers.index, { payload, properties })

--- a/test/ReplyStream.test.js
+++ b/test/ReplyStream.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const { EventEmitter } = require('node:events')
+const { once } = require('node:events')
+const { ReplyStream } = require('../source/.io/ReplyStream')
+
+/** @type {jest.Mock} */
+let reply
+
+/** @type {ReplyStream} */
+let stream
+
+beforeEach(() => {
+  global.COMQ_TESTING_MAX_BUFFER_SIZE = 3
+  global.COMQ_TESTING_IDLE_INTERVAL = 60_000
+
+  reply = jest.fn().mockResolvedValue(true)
+
+  const request = {
+    emitter: new EventEmitter(),
+    properties: { correlationId: 'test-correlation' }
+  }
+
+  stream = new ReplyStream(request, reply)
+})
+
+afterEach(() => {
+  delete global.COMQ_TESTING_MAX_BUFFER_SIZE
+  delete global.COMQ_TESTING_IDLE_INTERVAL
+
+  stream.destroy()
+})
+
+it('should destroy without calling reply when buffer overflows before control.ok', async () => {
+  const closed = once(stream, 'close')
+
+  for (let index = 1; index <= 5; index++) {
+    stream.arrange(index, { headers: { index } })
+  }
+
+  await closed
+
+  expect(stream.destroyed).toBe(true)
+  expect(reply).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- Fix ReplyStream crash when the reorder buffer overflows before `control.ok` (production TypeError on `request.properties`)
- Add unit test covering out-of-order buffer overflow without control confirmation

## Test plan
- [x] `npm test` (317 unit tests)
- [x] `npm run features:fast` (pre-push)


Made with [Cursor](https://cursor.com)