### PR TITLE
fix: do not report shards as lost on shutdown

### DIFF
--- a/source/connection.js
+++ b/source/connection.js
@@ -60,6 +60,10 @@ class Connection {
     return this.#connection !== undefined
   }
 
+  get closed () {
+    return this.#closed
+  }
+
   async open () {
     this.#closed = false
 

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -111,6 +111,7 @@ class Channel {
    * when it actually fails to publish, otherwise a lost connection would
    * interrupt the streams it is carrying. Losing a shard is reported instead,
    * since a request awaiting its reply on it will never be answered.
+   * A connection closed on purpose is not a loss.
    *
    * @param {comq.Connection} connection
    * @param {number} index
@@ -121,10 +122,13 @@ class Channel {
 
     if (connection.connected === false) this.#down[index].resolve()
 
-    connection.diagnose('close', () => {
+    connection.diagnose('close', (error) => {
       this.#alive[index] = false
       this.#down[index].resolve()
-      this.#diagnostics.emit(LOST, index)
+
+      if (error !== undefined && connection.closed !== true) {
+        this.#diagnostics.emit(LOST, index)
+      }
     })
 
     connection.diagnose('open', () => {

--- a/test/connection.mock.js
+++ b/test/connection.mock.js
@@ -20,6 +20,7 @@ const channel = /** @type {jest.MockedFunction<(sharded?: boolean, index?: numbe
  */
 const connection = (sharded = false) => (/** @type {jest.MockedObject<comq.Connection>} */ {
   connected: true,
+  closed: false,
   createChannel: jest.fn(async (type, index) => channel(sharded, index)),
   open: jest.fn(async () => undefined),
   close: jest.fn(async () => undefined),

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -402,6 +402,7 @@ describe('close', () => {
     const amqp = await amqplib.connect.mock.results[0].value
 
     expect(amqp.close).toHaveBeenCalled()
+    expect(connection.closed).toStrictEqual(true)
   })
 
   it('should close after connection is (re)established', async () => {

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -40,9 +40,43 @@ it('should report a lost shard', async () => {
 
   expect(calls.length).toBeGreaterThan(0)
 
-  for (const call of calls) call[1]()
+  for (const call of calls) call[1](new Error('gone'))
 
   expect(lost).toHaveBeenCalledWith(1)
+})
+
+it('should not report a lost shard when the connection is closed', async () => {
+  channel = await create(connections, type)
+
+  const lost = /** @type {jest.MockedFunction} */ jest.fn()
+
+  channel.diagnose('lost', lost)
+
+  connections[1].closed = true
+
+  const calls = connections[1].diagnose.mock.calls.filter((call) => call[0] === 'close')
+
+  expect(calls.length).toBeGreaterThan(0)
+
+  for (const call of calls) call[1](new Error('gone'))
+
+  expect(lost).not.toHaveBeenCalled()
+})
+
+it('should not report a lost shard when the connection is closed cleanly', async () => {
+  channel = await create(connections, type)
+
+  const lost = /** @type {jest.MockedFunction} */ jest.fn()
+
+  channel.diagnose('lost', lost)
+
+  const calls = connections[1].diagnose.mock.calls.filter((call) => call[0] === 'close')
+
+  expect(calls.length).toBeGreaterThan(0)
+
+  for (const call of calls) call[1]()
+
+  expect(lost).not.toHaveBeenCalled()
 })
 
 it('should not publish to a lost shard', async () => {

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -7,6 +7,7 @@ declare namespace comq {
 
   interface Connection {
     readonly connected?: boolean
+    readonly closed?: boolean
 
     open(): Promise<void>
 


### PR DESCRIPTION
## Summary
- Closing a connection is intentional, so it no longer emits `lost` or re-sends requests that will never be answered.
- Products were warning `AMQP shard lost` on every shutdown after the last recovery change.

## Test plan
- [x] Unit tests: a clean or purposeful close does not emit `lost`; an unexpected drop still does
- [x] `npm test` (standard + 342 jest tests)
- [ ] Shut down a sharded consumer/producer and confirm only `AMQP connection closed` is logged, not `AMQP shard lost`


Made with [Cursor](https://cursor.com)