### PR TITLE
fix: wait instead of publishing when every shard is down

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -491,7 +491,8 @@ Subscribe to one of the diagnostic events:
   Optional [`error`](https://amqp-node.github.io/amqplib/channel_api.html#model_events) is passed
   as an argument.
 - `error`: an attempt to restore the connection has failed. The exception is passed as an argument.
-  Attempts continue, so this event is the only way to observe an ongoing outage.
+  Attempts continue until one succeeds.
+- `reconnect`: an attempt to restore the connection has started. Followed by `open` or `error`.
 - `flow`: back pressure is applied to a channel. [Channel type](./types/topology.d.ts) is passed as
   an argument.
 - `drain`: back pressure is removed from a channel. Channel type is passed.
@@ -520,9 +521,12 @@ established, there is no way to capture the initial `open` event.
 ```javascript
 io.diagnose('flow', (type) => console.log(`Back pressure was applied to the ${type} channel`))
 
-io.diagnose('open', () => console.log('AMQP connection established'))
-io.diagnose('close', (error) => console.log('AMQP connection closed', error?.message))
-io.diagnose('error', (error) => console.log('AMQP connection failed', error.message))
+io.diagnose('reconnect', (shard) => console.log('AMQP reconnecting', { shard }))
+io.diagnose('open', (shard) => console.log('AMQP connection established', { shard }))
+io.diagnose('close', (error, shard) => console.log('AMQP connection closed', { message: error?.message, shard }))
+io.diagnose('error', (error, shard) => console.log('AMQP connection failed', { message: error.message, shard }))
+io.diagnose('lost', (type, shard) => console.log('AMQP shard lost', { type, shard }))
+io.diagnose('recover', (type, shard) => console.log('AMQP channel recovered', { type, shard }))
 ```
 
 # Gratitude

--- a/source/connection.js
+++ b/source/connection.js
@@ -73,6 +73,11 @@ class Connection {
 
     await this.#opening
 
+    if (this.#closed) return
+
+    // close may have landed after this attempt succeeded but before `#opening` was cleared
+    if (this.#connection === undefined) return this.open()
+
     this.#running = true
   }
 
@@ -109,16 +114,18 @@ class Connection {
   #open = async (retry) => {
     if (this.#closed) return
 
+    // the initial connect finishes before the caller can subscribe
+    if (this.#running) this.#diagnostics.emit('reconnect')
+
     /** @type {comq.amqp.Connection} */
     let connection
 
     try {
-      connection = await amqp.connect(this.#url, { timeout: CONNECT_MS })
+      connection = await this.#connect()
     } catch (exception) {
       if (this.#closed) return
       if (!this.#transient(exception)) throw exception
 
-      // attempts are made until one succeeds, so an outage is observable only here
       this.#diagnostics.emit('error', exception)
 
       return retry
@@ -198,6 +205,43 @@ class Connection {
 
   #recover () {
     return this.#recovery
+  }
+
+  /**
+   * amqplib's `timeout` is a socket idle timer and starts only after DNS.
+   * After a machine wakes, `getaddrinfo` itself can hang, so the attempt is
+   * also bounded here.
+   *
+   * @return {Promise<comq.amqp.Connection>}
+   */
+  async #connect () {
+    const connecting = amqp.connect(this.#url, { timeout: CONNECT_MS })
+
+    let timer
+
+    const expired = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => {
+        const exception = new Error('connect ETIMEDOUT')
+
+        exception.code = 'ETIMEDOUT'
+
+        reject(exception)
+      }, CONNECT_MS)
+
+      timer.unref()
+    })
+
+    expired.catch(noop)
+
+    try {
+      return await Promise.race([connecting, expired])
+    } catch (exception) {
+      connecting.then((connection) => this.#shutdown(connection), noop)
+
+      throw exception
+    } finally {
+      clearTimeout(timer)
+    }
   }
 
   /**

--- a/source/events.js
+++ b/source/events.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /** @type {comq.diagnostics.Event[]} */
-exports.connection = ['open', 'close', 'error']
+exports.connection = ['open', 'close', 'error', 'reconnect']
 
 /** @type {comq.diagnostics.Event[]} */
 exports.channel = ['flow', 'drain', 'recover', 'discard', 'pause', 'resume', 'return', 'lost']

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -318,26 +318,30 @@ class Channel {
   }
 
   /**
-   * The channels of the shards that are known to be connected, falling back to the
-   * whole pool while none is, so that a publish is attempted rather than dropped.
+   * The channels of the shards that are known to be connected.
+   * An empty result means every shard is down or benched — wait rather than
+   * publish: a destroyed socket accepts a write without complaining.
    *
    * @return {comq.Channel[]}
    */
   #reachable () {
-    const reachable = this.#pool.filter((channel) => this.#alive[channel.index] !== false)
-
-    return reachable.length === 0 ? this.#pool : reachable
+    return this.#pool.filter((channel) => this.#alive[channel.index] !== false)
   }
 
   /**
    * @param {(channel: comq.Channel) => void} fn
    */
   async #one (fn) {
-    if (this.#pool.length === 0) await this.#recovery
-
-    // publishing to a lost shard is silently accepted by the destroyed socket, so
-    // it must be avoided rather than retried: nothing would report the loss twice
+    // capture before the check: recover may replace `#recovery` in between
+    const waiting = this.#recovery
     const pool = this.#reachable()
+
+    if (pool.length === 0) {
+      await waiting
+
+      return this.#one(fn)
+    }
+
     const channel = pool[Math.floor(Math.random() * pool.length)]
 
     try {
@@ -345,7 +349,7 @@ class Channel {
     } catch {
       this.#remove(channel)
 
-      return await this.#one(fn)
+      return this.#one(fn)
     }
   }
 }

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -211,6 +211,41 @@ describe('reconnection', () => {
     expect(errors).toContain(exception)
   }, 10000)
 
+  it('should emit reconnect when restoring a lost connection', async () => {
+    const reconnect = jest.fn()
+
+    connection.diagnose('reconnect', reconnect)
+    conn.emit('close', new Error('lost'))
+
+    await connection.createChannel('event')
+
+    expect(reconnect).toHaveBeenCalled()
+  }, 10000)
+
+  it('should bound a connect that never settles', async () => {
+    jest.useFakeTimers()
+
+    try {
+      const errors = []
+
+      connection.diagnose('error', (exception) => errors.push(exception))
+      amqplib.connect.mockImplementation(() => new Promise(() => undefined))
+
+      conn.emit('close', new Error('lost'))
+
+      await jest.advanceTimersByTimeAsync(0)
+      await jest.advanceTimersByTimeAsync(30_000)
+
+      expect(errors).toEqual([expect.objectContaining({ code: 'ETIMEDOUT' })])
+
+      await jest.advanceTimersByTimeAsync(2_000)
+
+      expect(amqplib.connect.mock.calls.length).toBeGreaterThan(2)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it('should ignore close from a stale connection', async () => {
     const stale = conn
     const closeHandler = stale.on.mock.calls.find(([event]) => event === 'close')[1]
@@ -474,6 +509,21 @@ describe('diagnostics', () => {
     await connection.open()
 
     expect(captured).toStrictEqual(true)
+  })
+
+  it('should not emit reconnect on the initial open', async () => {
+    const reconnect = jest.fn()
+
+    connection.diagnose('reconnect', reconnect)
+
+    jest.clearAllMocks()
+
+    connection = new Connection(url)
+    connection.diagnose('reconnect', reconnect)
+
+    await connection.open()
+
+    expect(reconnect).not.toHaveBeenCalled()
   })
 
   it('should re-emit `close` event', async () => {

--- a/test/io.diagnostics.test.js
+++ b/test/io.diagnostics.test.js
@@ -61,7 +61,7 @@ it('should not throw on error without listeners', async () => {
   expect(() => emit(new Error(generate()))).not.toThrow()
 })
 
-it.each(['open', 'close'])('should re-emit %s from connection',
+it.each(['open', 'close', 'error', 'reconnect'])('should re-emit %s from connection',
   /**
    * @param {comq.diagnostics.Event} event
    */

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -96,6 +96,40 @@ it('should not publish to a lost shard', async () => {
   expect(channels[1].send).not.toHaveBeenCalled()
 })
 
+it('should wait for a shard to recover when all are lost', async () => {
+  channel = await create(connections, type)
+
+  const channels = await getCreatedChannels()
+  const buffer = randomBytes(8)
+  const label = generate()
+  let sent = false
+
+  for (const connection of connections) {
+    const calls = connection.diagnose.mock.calls.filter((call) => call[0] === 'close')
+
+    for (const call of calls) call[1](new Error('gone'))
+  }
+
+  const sending = channel.send(label, buffer).then(() => { sent = true })
+
+  await immediate()
+
+  expect(sent).toStrictEqual(false)
+
+  for (const chan of channels) expect(chan.send).not.toHaveBeenCalled()
+
+  const open = connections[0].diagnose.mock.calls.filter((call) => call[0] === 'open')
+  const recover = channels[0].diagnose.mock.calls.filter((call) => call[0] === 'recover')
+
+  for (const call of open) call[1]()
+  for (const call of recover) call[1]()
+
+  await sending
+
+  expect(channels[0].send).toHaveBeenCalled()
+  expect(channels[1].send).not.toHaveBeenCalled()
+})
+
 // a lost shard is not benched, so it is used again as soon as it reconnects
 it('should publish to a recovered shard', async () => {
   channel = await create(connections, type)

--- a/types/diagnostic.d.ts
+++ b/types/diagnostic.d.ts
@@ -1,7 +1,7 @@
 declare namespace comq.diagnostics {
 
-  type Event = 'open' | 'close' | 'error' | 'flow' | 'drain' | 'remove' | 'recover' | 'discard' |
-    'pause' | 'resume' | 'return'
+  type Event = 'open' | 'close' | 'error' | 'reconnect' | 'flow' | 'drain' | 'remove' | 'lost' |
+    'recover' | 'discard' | 'pause' | 'resume' | 'return'
 
   interface Diagnosable {
     diagnose(event: Event, listener: Function): void

--- a/types/io.d.ts
+++ b/types/io.d.ts
@@ -63,6 +63,8 @@ declare namespace comq {
 
     diagnose(event: 'error', listener: (error: Error, index?: number) => void): void
 
+    diagnose(event: 'reconnect', listener: (index?: number) => void): void
+
     diagnose(event: 'flow', listener: (channel: _topology.type, index?: number) => void): void
 
     diagnose(event: 'drain', listener: (channel: _topology.type, index?: number) => void): void


### PR DESCRIPTION
## Summary
- Promote #250 from `dev`: do not publish into a dead shard pool after sleep; bound hung connect; emit `reconnect`.

## Test plan
- [x] Merged to `dev` via #250
- [ ] CI on this PR
- [ ] Close the Mac lid, unlock, and confirm `reconnect` / `open` / `recover` (or `error`) appear instead of a silent hang


Made with [Cursor](https://cursor.com)