### PR TITLE
fix: recover from a connection that has gone silent

### DIFF
--- a/features/recovery.feature
+++ b/features/recovery.feature
@@ -84,6 +84,36 @@ Feature: Request-Reply Topology Recovery
     5
     """
 
+  Scenario: Sending another request while the broker is down
+
+  The reply queue is already being consumed from, so the request is published as soon as the
+  request channel recovers, which is before the reply queue has been declared again
+
+    Given function replying `add_numbers` queue:
+    """
+    ({ a, b }) => { return a + b }
+    """
+    When the consumer sends the following request to the `add_numbers` queue:
+    """yaml
+    a: 1
+    b: 2
+    """
+    Then the consumer receives the reply:
+    """yaml
+    3
+    """
+    When the broker has crashed
+    And the consumer sends the following request to the `add_numbers` queue:
+    """yaml
+    a: 2
+    b: 3
+    """
+    Then the broker is up
+    And the consumer receives the reply:
+    """yaml
+    5
+    """
+
   Scenario: Defining emitter while the broker is down
     Given the broker is down
     And `logger` consuming events from the `numbers_added` exchange is expected

--- a/features/silence.feature
+++ b/features/silence.feature
@@ -1,0 +1,39 @@
+Feature: Silent Connection Tolerance
+
+  A connection that has gone silent is what a machine that woke from sleep is
+  left with: the socket is open, neither the broker nor the operating system
+  reports anything, and nothing but the watchdog tells it from an idle connection.
+
+  Background:
+    Given watchdog interval is set to 2000ms with 60s AMQP heartbeat
+    And a network that can go silent
+
+  Scenario: Restoring a connection that has gone silent
+    Given an active connection to the broker
+    And a producer replying `echo` queue
+    When the network goes silent
+    Then the connection is lost within 10 seconds
+    When the consumer sends a request to the `echo` queue
+    Then the consumer receives the reply
+
+  Scenario: Restoring a sharded connection whose every shard has gone silent
+    Given an active sharded connection
+    And a producer replying `echo` queue
+    When the network goes silent
+    Then the connection is lost within 10 seconds
+    When the consumer sends a request to the `echo` queue
+    Then the consumer receives the reply
+
+  Scenario: Answering a request sent as the connection goes silent
+    Given an active connection to the broker
+    And a producer replying `echo` queue
+    When the consumer sends a request to the `echo` queue as the network goes silent
+    Then the consumer receives the reply
+    And the connection is lost within 10 seconds
+
+  Scenario: Answering a request sent as every shard goes silent
+    Given an active sharded connection
+    And a producer replying `echo` queue
+    When the consumer sends a request to the `echo` queue as the network goes silent
+    Then the consumer receives the reply
+    And the connection is lost within 10 seconds

--- a/features/silence.feature
+++ b/features/silence.feature
@@ -37,3 +37,10 @@ Feature: Silent Connection Tolerance
     When the consumer sends a request to the `echo` queue as the network goes silent
     Then the consumer receives the reply
     And the connection is lost within 10 seconds
+
+  Scenario: Reporting that there is nowhere left to publish
+    Given an active sharded connection
+    And a producer replying `echo` queue
+    When the network goes silent
+    Then publishing is paused within 10 seconds
+    And publishing is resumed within 10 seconds

--- a/features/steps/.types/context.d.ts
+++ b/features/steps/.types/context.d.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream'
+import { Socket } from 'node:net'
 import * as _diagnostics from '../../../types/diagnostic'
 import * as _io from '../../../types/io'
 import * as _amqp from '../../../types/amqp'
@@ -34,10 +35,26 @@ declare namespace comq.features {
     streamsValues: Record<number, any[]>
     streamsEnded: Record<number, boolean>
     generatorDestroyed: boolean
+    networks: Network[]
 
     connect(user?: string, password?: string): Promise<void>
     assert(user?: string, password?: string): Promise<void>
     disconnect(): Promise<void>
+    unplug(): Promise<void>
+  }
+
+  interface Network {
+    readonly address: string
+
+    open(): Promise<void>
+    silence(): void
+    close(): Promise<void>
+  }
+
+  interface Tunnel {
+    client: Socket
+    upstream: Socket
+    silent: boolean
   }
 
 }

--- a/features/steps/connection.js
+++ b/features/steps/connection.js
@@ -173,11 +173,19 @@ Then('the connection is lost within {number} second(s)',
    * @this {comq.features.Context}
    */
   async function (seconds) {
-    const deadline = Date.now() + seconds * 1000
+    await emitted.call(this, 'close', seconds, 'connection was not lost')
+  })
 
-    while (this.events.close !== true && Date.now() < deadline) await timeout(50)
+Then('publishing is {paused-event} within {number} second(s)',
+  /**
+   * @param {'paused' | 'resumed'} key
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (key, seconds) {
+    const event = PUBLISHING_EVENTS[key]
 
-    assert.equal(this.events.close, true, 'connection was not lost')
+    await emitted.call(this, event, seconds, 'publishing was not ' + key)
   })
 
 Given('the connection has started sealing',
@@ -208,6 +216,25 @@ const connect = async (context, user, password) => {
   } catch (exception) {
     context.exception = exception instanceof AggregateError ? exception.errors[0] : exception
   }
+}
+
+/**
+ * @param {comq.diagnostics.Event} event
+ * @param {number} seconds
+ * @param {string} message
+ * @this {comq.features.Context}
+ */
+async function emitted (event, seconds, message) {
+  const deadline = Date.now() + seconds * 1000
+
+  while (this.events[event] !== true && Date.now() < deadline) await timeout(50)
+
+  assert.equal(this.events[event], true, message)
+}
+
+const PUBLISHING_EVENTS = {
+  paused: 'pause',
+  resumed: 'resume'
 }
 
 const CONNECTION_EVENTS = {

--- a/features/steps/connection.js
+++ b/features/steps/connection.js
@@ -167,6 +167,19 @@ Then('the connection is {connection-event}',
     assert.equal(this.events[event], true, 'connection was not ' + key)
   })
 
+Then('the connection is lost within {number} second(s)',
+  /**
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (seconds) {
+    const deadline = Date.now() + seconds * 1000
+
+    while (this.events.close !== true && Date.now() < deadline) await timeout(50)
+
+    assert.equal(this.events.close, true, 'connection was not lost')
+  })
+
 Given('the connection has started sealing',
   /**
    * @this {comq.features.Context}

--- a/features/steps/context.js
+++ b/features/steps/context.js
@@ -34,6 +34,9 @@ class Context extends World {
   streamsEnded = {}
   generatorDestroyed = false
 
+  /** @type {comq.features.Network[]} */
+  networks = []
+
   async connect (user, password) {
     const urls = this.#urls(user, password)
 
@@ -44,6 +47,12 @@ class Context extends World {
     const urls = this.#urls(user, password)
 
     await this.#connect(urls, assert)
+  }
+
+  async unplug () {
+    await Promise.all(this.networks.map((network) => network.close()))
+
+    this.networks = []
   }
 
   async disconnect () {
@@ -89,7 +98,8 @@ class Context extends World {
   }
 
   #url (i, user, password) {
-    const url = PROTOCOL + user + ':' + password + '@' + getAddress(i)
+    const address = this.networks[i]?.address ?? getAddress(i)
+    const url = PROTOCOL + user + ':' + password + '@' + address
     const heartbeat = global.COMQ_TESTING_AMQP_HEARTBEAT
 
     // the watchdog measures silence, so it may only be shortened along with the

--- a/features/steps/context.js
+++ b/features/steps/context.js
@@ -111,6 +111,6 @@ class Context extends World {
 const PROTOCOL = 'amqp://'
 
 /** @type {comq.diagnostics.Event[]} */
-const EVENTS = ['open', 'close', 'flow', 'discard']
+const EVENTS = ['open', 'close', 'flow', 'discard', 'pause', 'resume']
 
 exports.Context = Context

--- a/features/steps/hooks.js
+++ b/features/steps/hooks.js
@@ -20,6 +20,7 @@ After(
     )
 
     await this.disconnect()
+    await this.unplug()
   })
 
 AfterAll(async function () {

--- a/features/steps/network.js
+++ b/features/steps/network.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { Given, When } = require('@cucumber/cucumber')
+const { BROKERS_AMOUNT } = require('./brokers')
+const { Network } = require('./networks')
+
+Given('a network that can go silent',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    for (let n = 0; n < BROKERS_AMOUNT; n++) {
+      const network = new Network(n)
+
+      await network.open()
+
+      this.networks[n] = network
+    }
+  })
+
+When('the network goes silent',
+  /**
+   * @this {comq.features.Context}
+   */
+  function () {
+    silence.call(this)
+  })
+
+// a request that is answered over a connection that is already silent proves
+// nothing, hence the window between the two is left as short as a step boundary
+When('the consumer sends a request to the {token} queue as the network goes silent',
+  /**
+   * @param {string} queue
+   * @this {comq.features.Context}
+   */
+  function (queue) {
+    this.reply = this.io.request(queue, 'hello')
+
+    silence.call(this)
+  })
+
+/**
+ * @this {comq.features.Context}
+ */
+function silence () {
+  // only a connection lost from now on counts as lost
+  delete this.events.close
+
+  for (const network of this.networks) network.silence()
+}

--- a/features/steps/networks.js
+++ b/features/steps/networks.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const net = require('node:net')
+const { getAddress } = require('./brokers')
+
+/**
+ * A network that can go silent, which is what a machine that woke from sleep is
+ * left with: the socket stays open, nothing is delivered over it, and neither
+ * the broker nor the operating system reports anything. Stopping, killing or
+ * pausing a broker does not reproduce it, since all three end up closing the
+ * socket the moment the connection is used.
+ */
+class Network {
+  /** @type {net.Server} */
+  #server
+
+  /** @type {Set<comq.features.Tunnel>} */
+  #tunnels = new Set()
+
+  /** @type {string} */
+  #host
+
+  /** @type {number} */
+  #port
+
+  /**
+   * @param {number} [n] broker index
+   */
+  constructor (n = 0) {
+    const [host, port] = getAddress(n).split(':')
+
+    this.#host = host
+    this.#port = Number(port)
+  }
+
+  get address () {
+    return 'localhost:' + this.#server.address().port
+  }
+
+  async open () {
+    this.#server = net.createServer(this.#tunnel)
+
+    await new Promise((resolve) => this.#server.listen(0, '127.0.0.1', resolve))
+  }
+
+  /**
+   * Only the tunnels that are already open go silent: a connection established
+   * afterwards is forwarded as usual, just as it is once a machine is awake.
+   */
+  silence () {
+    for (const tunnel of this.#tunnels) tunnel.silent = true
+  }
+
+  async close () {
+    for (const tunnel of this.#tunnels) this.#collapse(tunnel)
+
+    await new Promise((resolve) => this.#server.close(resolve))
+  }
+
+  /**
+   * @param {net.Socket} client
+   */
+  #tunnel = (client) => {
+    const upstream = net.connect(this.#port, this.#host)
+
+    /** @type {comq.features.Tunnel} */
+    const tunnel = { client, upstream, silent: false }
+
+    this.#tunnels.add(tunnel)
+
+    client.on('data', (chunk) => { if (!tunnel.silent) upstream.write(chunk) })
+    upstream.on('data', (chunk) => { if (!tunnel.silent) client.write(chunk) })
+
+    for (const socket of [client, upstream]) {
+      socket.on('error', () => this.#collapse(tunnel))
+      socket.on('close', () => this.#collapse(tunnel))
+    }
+  }
+
+  /**
+   * @param {comq.features.Tunnel} tunnel
+   */
+  #collapse (tunnel) {
+    this.#tunnels.delete(tunnel)
+    tunnel.client.destroy()
+    tunnel.upstream.destroy()
+  }
+}
+
+exports.Network = Network

--- a/features/steps/parameters.js
+++ b/features/steps/parameters.js
@@ -39,6 +39,12 @@ defineParameterType({
 })
 
 defineParameterType({
+  name: 'paused-event',
+  regexp: /(paused|resumed)/,
+  transformer: (value) => value
+})
+
+defineParameterType({
   name: 'message',
   regexp: /(request|event)/,
   transformer: (value) => value

--- a/readme.md
+++ b/readme.md
@@ -501,7 +501,7 @@ Subscribe to one of the diagnostic events:
 - `flow`: back pressure is applied to a channel. [Channel type](./types/topology.d.ts) is passed as
   an argument.
 - `drain`: back pressure is removed from a channel. Channel type is passed.
-- `remove`: channel is removed from the [pool](#sharded-connection).
+- `remove`: channel is removed from the [pool](#sharded-connection), having failed to publish.
 - `lost`: a shard has lost its connection, hence the requests awaiting their replies on it are
   re-sent. Channel type is passed.
 - `recover`: channel's topology is recovered. Channel type is passed.
@@ -509,7 +509,13 @@ Subscribe to one of the diagnostic events:
   exceptions. Channel type,
   raw [amqp message object](https://amqp-node.github.io/amqplib/channel_api.html#channel_consume)
   and the exception are passed as arguments.
+- `return`: message is returned by the broker as unroutable. Channel type and the raw
+  [amqp message object](https://amqp-node.github.io/amqplib/channel_api.html#channel_publish) are
+  passed as arguments. In the case of a [sharded connection](#sharded-connection), the message is
+  reported only once every shard has rejected it.
 - `pause`: channel is paused. Channel type is passed.
+  In the case of a [sharded connection](#sharded-connection), it means that there is no shard left
+  to publish to, be it because every one of them has rejected a publish or lost its connection.
 - `resume`: channel is resumed. Channel type is passed.
 
 In the case of a [sharded connection](#sharded-connection), an additional argument specifying the

--- a/readme.md
+++ b/readme.md
@@ -313,6 +313,12 @@ the connection is restored.
 
 When the established connection is lost, it will be automatically restored.
 Reconnection attempts will be made indefinitely, with intervals increasing up to 30 seconds.
+Unless the URL sets one, a 15 second heartbeat is requested, so that a connection that is gone
+without a word, such as after a machine wakes from sleep, is noticed within a minute instead of
+being left to whatever the broker suggests.
+A connection that stays silent for three heartbeats is destroyed regardless of what the broker and
+the operating system have reported, since neither is guaranteed to report anything at all.
+Requesting `heartbeat=0` disables both.
 If the broker rejects the connection, for example, due to access being denied, an exception will be thrown.
 Once reconnected, the topology will be recovered, and any unanswered requests and unconfirmed events will be
 retransmitted.

--- a/source/connection.js
+++ b/source/connection.js
@@ -200,7 +200,14 @@ class Connection {
     }
 
     connection.removeAllListeners()
-    connection.connection?.stream?.destroy()
+
+    // amqplib keeps its heartbeater running on a connection it does not know is
+    // gone and emits 'error' on it, which throws once no listener is left
+    connection.on('error', noop)
+
+    // a socket destroyed without an error tells amqplib nothing, leaving its
+    // timers running and everything pending on it hanging forever
+    connection.connection?.stream?.destroy(silence())
   }
 
   #recover () {
@@ -255,7 +262,11 @@ class Connection {
 
     const reset = () => {
       clearTimeout(this.#heartbeatTimer)
-      this.#heartbeatTimer = setTimeout(() => socket.destroy(), timeoutMs)
+      // destroying a socket without an error tells amqplib nothing: it only
+      // listens for 'error' and 'end', so a bare destroy() leaves the connection
+      // silently dead — no 'close' event, no recovery, every pending operation
+      // hanging forever
+      this.#heartbeatTimer = setTimeout(() => socket.destroy(silence()), timeoutMs)
       this.#heartbeatTimer.unref()
     }
 
@@ -321,6 +332,17 @@ function expiration () {
   const timeoutMs = global.COMQ_TESTING_SHUTDOWN_TIMEOUT ?? SHUTDOWN_MS
 
   return delay(timeoutMs, undefined, { ref: false })
+}
+
+/**
+ * @return {Error}
+ */
+function silence () {
+  const exception = new Error('Connection is silent')
+
+  exception.code = 'ETIMEDOUT'
+
+  return exception
 }
 
 function noop () {}

--- a/source/connection.js
+++ b/source/connection.js
@@ -51,9 +51,6 @@ class Connection {
    */
   constructor (url) {
     this.#url = heartbeaten(url)
-
-    // EventEmitter throws on 'error' with no listeners
-    this.#diagnostics.on('error', noop)
   }
 
   get connected () {

--- a/source/connection.js
+++ b/source/connection.js
@@ -50,7 +50,7 @@ class Connection {
    * @param {string} url
    */
   constructor (url) {
-    this.#url = url
+    this.#url = heartbeaten(url)
 
     // EventEmitter throws on 'error' with no listeners
     this.#diagnostics.on('error', noop)
@@ -222,7 +222,7 @@ class Connection {
    * @return {Promise<comq.amqp.Connection>}
    */
   async #connect () {
-    const connecting = amqp.connect(this.#url, { timeout: CONNECT_MS })
+    const connecting = amqp.connect(this.#url, SOCKET_OPTIONS)
 
     let timer
 
@@ -255,10 +255,12 @@ class Connection {
    * @param {comq.amqp.Connection} connection
    * @param {number} [timeoutMs]
    */
-  #armWatchdog (connection, timeoutMs = global.COMQ_TESTING_WATCHDOG_INTERVAL ?? WATCHDOG_MS) {
+  #armWatchdog (connection, timeoutMs = tolerance(connection)) {
+    this.#disarmWatchdog()
+
     const socket = connection.connection?.stream
 
-    if (socket === undefined) return
+    if (socket === undefined || timeoutMs === undefined) return
 
     const reset = () => {
       clearTimeout(this.#heartbeatTimer)
@@ -269,8 +271,6 @@ class Connection {
       this.#heartbeatTimer = setTimeout(() => socket.destroy(silence()), timeoutMs)
       this.#heartbeatTimer.unref()
     }
-
-    this.#disarmWatchdog()
 
     this.#heartbeatSocket = socket
     this.#heartbeatReset = reset
@@ -300,7 +300,25 @@ class Connection {
   }
 }
 
+/**
+ * The heartbeat to ask for when the caller has not, in seconds. A broker is free
+ * to suggest one that leaves a connection lost for minutes before anything
+ * notices, and RabbitMQ suggests 60 by default.
+ *
+ * @type {number}
+ */
+const HEARTBEAT_S = 15
+
 /** @type {number} */
+const KEEPALIVE_MS = 10_000
+
+/** How many heartbeats a connection may miss before it is destroyed. */
+const MISSED_HEARTBEATS = 3
+
+/** @type {number} */
+const WATCHDOG_MIN_MS = 15_000
+
+/** The watchdog interval used when the negotiated heartbeat is unknown. */
 const WATCHDOG_MS = 60_000
 
 /** @type {number} */
@@ -308,6 +326,15 @@ const CONNECT_MS = 30_000
 
 /** @type {number} */
 const SHUTDOWN_MS = 5_000
+
+const SOCKET_OPTIONS = {
+  timeout: CONNECT_MS,
+  // a peer that went away without a word is noticed by the kernel as well
+  keepAlive: true,
+  keepAliveDelay: KEEPALIVE_MS
+}
+
+const HEARTBEAT_SET = /[?&]heartbeat=/
 
 const TRANSIENT_CODES = new Set([
   'ECONNREFUSED',
@@ -332,6 +359,41 @@ function expiration () {
   const timeoutMs = global.COMQ_TESTING_SHUTDOWN_TIMEOUT ?? SHUTDOWN_MS
 
   return delay(timeoutMs, undefined, { ref: false })
+}
+
+/**
+ * amqplib reads the heartbeat from the URL only, hence it cannot be passed along
+ * with the socket options.
+ *
+ * @param {string} url
+ * @return {string}
+ */
+function heartbeaten (url) {
+  if (HEARTBEAT_SET.test(url)) return url
+
+  return url + (url.includes('?') ? '&' : '?') + 'heartbeat=' + HEARTBEAT_S
+}
+
+/**
+ * The watchdog measures silence, so it cannot be shorter than the interval at
+ * which a healthy broker is expected to say something, which is a heartbeat
+ * frame every half a heartbeat. A connection that has agreed to no heartbeats
+ * says nothing at all while it is idle, leaving nothing to measure.
+ *
+ * @param {comq.amqp.Connection} connection
+ * @return {number | undefined}
+ */
+function tolerance (connection) {
+  const override = global.COMQ_TESTING_WATCHDOG_INTERVAL
+
+  if (override !== undefined) return override
+
+  const heartbeat = connection.connection?.heartbeat
+
+  if (heartbeat === undefined) return WATCHDOG_MS
+  if (heartbeat === 0) return undefined
+
+  return Math.max(heartbeat * MISSED_HEARTBEATS * 1000, WATCHDOG_MIN_MS)
 }
 
 /**

--- a/source/emitter.js
+++ b/source/emitter.js
@@ -2,8 +2,30 @@
 
 const { EventEmitter } = require('node:events')
 
+/**
+ * A listener must not be able to break what it observes: an exception thrown by
+ * one used to leave the reconnection it was reporting on unfinished, or take the
+ * process down through the emitter amqplib was calling.
+ */
+class Emitter extends EventEmitter {
+  emit (event, ...args) {
+    // raw listeners are used so that `once` still removes itself
+    const listeners = this.rawListeners(event)
+
+    for (const listener of listeners) {
+      try {
+        listener.apply(this, args)
+      } catch {
+        // a diagnostic listener has no one to report to
+      }
+    }
+
+    return listeners.length > 0
+  }
+}
+
 function create () {
-  const emitter = new EventEmitter()
+  const emitter = new Emitter()
 
   emitter.setMaxListeners(0)
 

--- a/source/events.js
+++ b/source/events.js
@@ -4,4 +4,4 @@
 exports.connection = ['open', 'close', 'error', 'reconnect']
 
 /** @type {comq.diagnostics.Event[]} */
-exports.channel = ['flow', 'drain', 'recover', 'discard', 'pause', 'resume', 'return', 'lost']
+exports.channel = ['flow', 'drain', 'recover', 'discard', 'pause', 'resume', 'return', 'lost', 'remove']

--- a/source/io.js
+++ b/source/io.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const stream = require('node:stream')
-const { EventEmitter } = require('node:events')
 const { randomBytes } = require('node:crypto')
 const { setTimeout } = require('node:timers/promises')
 const { Promex } = require('promex')
@@ -11,6 +10,7 @@ const { decode } = require('./decode')
 const { encode } = require('./encode')
 const { pipeline, transform } = require('./pipeline')
 const events = require('./events')
+const emitter = require('./emitter')
 const io = require('./.io')
 
 /**
@@ -44,16 +44,13 @@ class IO {
   /** @type {Set<comq.Destroyable>} */
   #replyPipes = new Set()
 
-  #diagnostics = new EventEmitter()
+  #diagnostics = emitter.create()
 
   /**
    * @param {comq.Connection} connection
    */
   constructor (connection) {
     this.#connection = connection
-
-    // EventEmitter throws on 'error' with no listeners
-    this.#diagnostics.on('error', noop)
 
     for (const event of events.connection) {
       this.#connection.diagnose(event, (...args) => this.#diagnostics.emit(event, ...args))

--- a/source/io.js
+++ b/source/io.js
@@ -220,6 +220,10 @@ class IO {
     } else {
       this.#requests.diagnose('recover', this.#retransmit)
     }
+
+    // a reply that could not be routed is dropped by the broker, and the queue
+    // it was addressed to only exists again once this channel has recovered
+    this.#replies.diagnose('recover', this.#retransmit)
   }
 
   /**

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -31,6 +31,9 @@ class Channel {
   /** @type {Map<comq.Channel, Promex>} */
   #bench = new Map()
 
+  /** @type {boolean} */
+  #paused = false
+
   /** @type {comq.topology.type} */
   #type
 
@@ -126,6 +129,9 @@ class Channel {
       this.#alive[index] = false
       this.#down[index].resolve()
 
+      // the channel stays in the pool, yet there is one less shard to publish to
+      this.#update()
+
       if (error !== undefined && connection.closed !== true) {
         this.#diagnostics.emit(LOST, index)
       }
@@ -134,6 +140,8 @@ class Channel {
     connection.diagnose('open', () => {
       this.#alive[index] = true
       this.#down[index] = new Promex()
+
+      this.#update()
     })
   }
 
@@ -159,6 +167,7 @@ class Channel {
     for (const event of events.channel) {
       if (event === RETURN) continue // returns are retried before being reported
       if (event === LOST) continue // a shard is lost with its connection, not its channel
+      if (event === REMOVE) continue // it is the pool that removes a channel, not the channel
 
       channel.diagnose(event, (...args) => this.#diagnostics.emit(event, ...args, channel.index))
     }
@@ -214,20 +223,23 @@ class Channel {
     this.#bench.set(channel, new Promex())
     this.#channels.delete(channel)
     this.#update()
-    this.#diagnostics.emit('remove', channel.index)
+    this.#diagnostics.emit(REMOVE, channel.index)
   }
 
+  /**
+   * A shard leaves the pool when it rejects a publish, and stops being reachable
+   * when its connection is lost, which the pool is not told about. Both leave
+   * `#one` waiting, so both are reported the same way.
+   */
   #update () {
-    const from = this.#pool?.length
-    const to = this.#channels.size
-
     this.#pool = Array.from(this.#channels)
 
-    if (from === undefined) return
+    const paused = this.#reachable().length === 0
 
-    if (from !== 0 && to === 0) { this.#diagnostics.emit('pause') }
+    if (paused === this.#paused) return
 
-    if (from === 0 && to !== 0) { this.#diagnostics.emit('resume') }
+    this.#paused = paused
+    this.#diagnostics.emit(paused ? 'pause' : 'resume')
   }
 
   /**
@@ -369,6 +381,7 @@ async function create (connections, type) {
 
 const DEFAULT = ''
 const RETURN = 'return'
+const REMOVE = 'remove'
 const RETURN_HEADER = 'x-return'
 const LOST = 'lost'
 

--- a/source/shards/connection.js
+++ b/source/shards/connection.js
@@ -19,9 +19,6 @@ class Connection {
   constructor (connections) {
     this.#connections = connections
 
-    // EventEmitter throws on 'error' with no listeners
-    this.#diagnostics.on('error', noop)
-
     connections.map(this.#pipe)
   }
 
@@ -74,7 +71,5 @@ class Connection {
     throw exception
   }
 }
-
-function noop () {}
 
 exports.Connection = Connection

--- a/test/amqplib.mock.js
+++ b/test/amqplib.mock.js
@@ -23,7 +23,16 @@ class Connection extends EventEmitter {
 
     const stream = new EventEmitter()
 
-    stream.destroy = jest.fn()
+    // amqplib listens for 'error' and 'end' on the socket only, so destroying it
+    // without an error leaves the connection unaware and silent forever
+    stream.destroy = jest.fn((error) => {
+      if (error === undefined || stream.destroyed === true) return
+
+      stream.destroyed = true
+
+      this.emit('error', error)
+      this.emit('close', error)
+    })
 
     this.connection = { stream }
 

--- a/test/amqplib.mock.js
+++ b/test/amqplib.mock.js
@@ -18,7 +18,7 @@ class Channel extends EventEmitter {
 }
 
 class Connection extends EventEmitter {
-  constructor () {
+  constructor (url = '') {
     super()
 
     const stream = new EventEmitter()
@@ -34,7 +34,10 @@ class Connection extends EventEmitter {
       this.emit('close', error)
     })
 
-    this.connection = { stream }
+    // a broker accepts the heartbeat the client asks for
+    const heartbeat = Number(/[?&]heartbeat=(\d+)/.exec(url)?.[1] ?? 60)
+
+    this.connection = { stream, heartbeat }
 
     // noinspection JSValidateTypes
     this.removeAllListeners = jest.spyOn(this, 'removeAllListeners')
@@ -48,7 +51,7 @@ class Connection extends EventEmitter {
   close = jest.fn(async () => undefined)
 }
 
-const connect = async () => new Connection()
+const connect = async (url) => new Connection(url)
 
 /** @type {jest.MockedObject<import('amqplib')>} */
 const amqplib = {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -38,7 +38,8 @@ describe('initial connection', () => {
   it('should connect', async () => {
     await connection.open()
 
-    expect(amqplib.connect).toHaveBeenCalledWith(url, { timeout: expect.any(Number) })
+    expect(amqplib.connect).toHaveBeenCalledWith(expect.stringContaining(url),
+      expect.objectContaining({ timeout: expect.any(Number) }))
   })
 
   it.each(/** @type {[string, Partial<Error>][]} */[
@@ -397,7 +398,7 @@ describe('watchdog', () => {
 
     const conn = await amqplib.connect.mock.results[0].value
 
-    await jest.advanceTimersByTimeAsync(60_000)
+    await jest.advanceTimersByTimeAsync(46_000)
 
     expect(conn.connection.stream.destroy).toHaveBeenCalled()
   })
@@ -407,7 +408,7 @@ describe('watchdog', () => {
 
     await connection.open()
 
-    await jest.advanceTimersByTimeAsync(60_000)
+    await jest.advanceTimersByTimeAsync(46_000)
 
     // a socket destroyed without an error is a socket amqplib never reports,
     // which leaves the connection silently dead instead of recovering
@@ -443,17 +444,88 @@ describe('watchdog', () => {
 
     const conn = await amqplib.connect.mock.results[0].value
 
-    await jest.advanceTimersByTimeAsync(50_000)
+    await jest.advanceTimersByTimeAsync(40_000)
 
     conn.connection.stream.emit('data', Buffer.alloc(0))
 
-    await jest.advanceTimersByTimeAsync(50_000)
+    await jest.advanceTimersByTimeAsync(40_000)
 
     expect(conn.connection.stream.destroy).not.toHaveBeenCalled()
 
     await jest.advanceTimersByTimeAsync(10_000)
 
     expect(conn.connection.stream.destroy).toHaveBeenCalled()
+  })
+
+  it('should derive the watchdog from the negotiated heartbeat', async () => {
+    jest.useFakeTimers()
+
+    const connection = new Connection('amqp://localhost?heartbeat=30')
+
+    await connection.open()
+
+    const conn = await amqplib.connect.mock.results[0].value
+
+    // the broker is only expected to say something every 15 seconds
+    await jest.advanceTimersByTimeAsync(60_000)
+
+    expect(conn.connection.stream.destroy).not.toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(31_000)
+
+    expect(conn.connection.stream.destroy).toHaveBeenCalled()
+  })
+
+  it('should not arm the watchdog when heartbeats are disabled', async () => {
+    jest.useFakeTimers()
+
+    const connection = new Connection('amqp://localhost?heartbeat=0')
+
+    await connection.open()
+
+    const conn = await amqplib.connect.mock.results[0].value
+
+    // an idle connection that has agreed to no heartbeats is silent by design
+    await jest.advanceTimersByTimeAsync(600_000)
+
+    expect(conn.connection.stream.destroy).not.toHaveBeenCalled()
+  })
+})
+
+describe('heartbeat', () => {
+  it('should ask for a heartbeat', async () => {
+    const connection = new Connection('amqp://developer@localhost')
+
+    await connection.open()
+
+    expect(amqplib.connect).toHaveBeenCalledWith('amqp://developer@localhost?heartbeat=15',
+      expect.anything())
+  })
+
+  it('should append the heartbeat to an existing query', async () => {
+    const connection = new Connection('amqp://localhost?frameMax=8192')
+
+    await connection.open()
+
+    expect(amqplib.connect).toHaveBeenCalledWith('amqp://localhost?frameMax=8192&heartbeat=15',
+      expect.anything())
+  })
+
+  it.each(['amqp://localhost?heartbeat=5', 'amqp://localhost?heartbeat=0'])(
+    'should keep the heartbeat requested by the caller (%s)',
+    async (url) => {
+      const connection = new Connection(url)
+
+      await connection.open()
+
+      expect(amqplib.connect).toHaveBeenCalledWith(url, expect.anything())
+    })
+
+  it('should keep the socket alive', async () => {
+    await connection.open()
+
+    expect(amqplib.connect)
+      .toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ keepAlive: true }))
   })
 })
 

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -139,6 +139,29 @@ describe('reconnection', () => {
     expect(amqplib.connect.mock.calls.length).toBeGreaterThanOrEqual(3)
   }, 15000)
 
+  it('should keep an error sink on a dropped connection', async () => {
+    const channel = await connection.createChannel('request')
+
+    channel.recover
+      .mockRejectedValueOnce(new Error('Channel closed'))
+      .mockResolvedValue(undefined)
+
+    conn.emit('close', new Error('lost'))
+
+    await timeout(10)
+
+    const dropped = await amqplib.connect.mock.results[1].value
+
+    // amqplib goes on emitting on a connection it does not know is gone, and an
+    // 'error' with no listener left takes the process down
+    expect(() => dropped.emit('error', new Error('Heartbeat timeout'))).not.toThrow()
+
+    // let the attempt that follows the failed recovery settle
+    const start = Date.now()
+
+    while (channel.recover.mock.calls.length < 2 && Date.now() - start < 10000) await timeout(50)
+  }, 15000)
+
   it('should emit error when reconnect open fails', async () => {
     const errors = []
     const unhandled = jest.fn()
@@ -377,6 +400,18 @@ describe('watchdog', () => {
     await jest.advanceTimersByTimeAsync(60_000)
 
     expect(conn.connection.stream.destroy).toHaveBeenCalled()
+  })
+
+  it('should reconnect after the watchdog destroys a silent connection', async () => {
+    jest.useFakeTimers()
+
+    await connection.open()
+
+    await jest.advanceTimersByTimeAsync(60_000)
+
+    // a socket destroyed without an error is a socket amqplib never reports,
+    // which leaves the connection silently dead instead of recovering
+    expect(amqplib.connect).toHaveBeenCalledTimes(2)
   })
 
   it('should not let a replaced socket disarm the watchdog', async () => {

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -163,6 +163,18 @@ describe('reconnection', () => {
     while (channel.recover.mock.calls.length < 2 && Date.now() - start < 10000) await timeout(50)
   }, 15000)
 
+  it('should reconnect despite a listener that throws', async () => {
+    // a diagnostic listener has no business breaking the reconnection it reports
+    connection.diagnose('reconnect', () => { throw new Error('listener') })
+    connection.diagnose('open', () => { throw new Error('listener') })
+
+    conn.emit('close', new Error('lost'))
+
+    await expect(connection.createChannel('event')).resolves.toBeDefined()
+
+    expect(amqplib.connect).toHaveBeenCalledTimes(2)
+  }, 10000)
+
   it('should emit error when reconnect open fails', async () => {
     const errors = []
     const unhandled = jest.fn()

--- a/test/emitter.test.js
+++ b/test/emitter.test.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const { generate } = require('randomstring')
+const emitter = require('../source/emitter')
+
+/** @type {import('node:events').EventEmitter} */
+let instance
+
+beforeEach(() => {
+  instance = emitter.create()
+})
+
+it('should be', async () => {
+  expect(emitter.create).toBeInstanceOf(Function)
+})
+
+it('should emit', async () => {
+  const listener = jest.fn()
+  const event = generate()
+  const args = [generate(), generate()]
+
+  instance.on(event, listener)
+
+  expect(instance.emit(event, ...args)).toStrictEqual(true)
+  expect(listener).toHaveBeenCalledWith(...args)
+})
+
+it('should report an event no one listens to', async () => {
+  expect(instance.emit(generate())).toStrictEqual(false)
+})
+
+it('should not throw on error without listeners', async () => {
+  expect(() => instance.emit('error', new Error(generate()))).not.toThrow()
+})
+
+it('should not let a listener break the emission', async () => {
+  const event = generate()
+  const listener = jest.fn()
+
+  instance.on(event, () => { throw new Error(generate()) })
+  instance.on(event, listener)
+
+  expect(() => instance.emit(event)).not.toThrow()
+
+  // the listeners that follow a broken one are still called
+  expect(listener).toHaveBeenCalled()
+})
+
+it('should call a `once` listener once', async () => {
+  const event = generate()
+  const listener = jest.fn()
+
+  instance.once(event, listener)
+
+  instance.emit(event)
+  instance.emit(event)
+
+  expect(listener).toHaveBeenCalledTimes(1)
+})
+
+it('should not call a listener that has been removed', async () => {
+  const event = generate()
+  const listener = jest.fn()
+
+  instance.on(event, listener)
+  instance.off(event, listener)
+
+  instance.emit(event)
+
+  expect(listener).not.toHaveBeenCalled()
+})

--- a/test/io.diagnostics.test.js
+++ b/test/io.diagnostics.test.js
@@ -28,7 +28,7 @@ describe.each(['request', 'reply', 'event'])('%s channel events',
    * @param {comq.topology.type} type
    */
   (type) => {
-    it.each(['flow', 'drain', 'recover', 'discard', 'pause', 'resume'])('should re-emit %s',
+    it.each(['flow', 'drain', 'recover', 'discard', 'pause', 'resume', 'lost', 'remove'])('should re-emit %s',
       /**
        * @param {comq.diagnostics.Event} event
        */

--- a/test/io.request.test.js
+++ b/test/io.request.test.js
@@ -182,6 +182,20 @@ describe('send', () => {
     expect(requests.send).toHaveBeenCalledTimes(2)
   })
 
+  // a reply that could not be routed has been dropped by the broker
+  it('should resend unanswered Requests when the reply channel recovers', async () => {
+    expect(replies.diagnose).toHaveBeenCalledWith('recover', expect.any(Function))
+
+    const calls = replies.diagnose.mock.calls.filter((call) => call[0] === 'recover')
+    const listeners = calls.map((call) => call[1])
+
+    for (const listener of listeners) listener()
+
+    await immediate()
+
+    expect(requests.send).toHaveBeenCalledTimes(2)
+  })
+
   it('should resend unanswered Requests on sharded connection', async () => {
     jest.clearAllMocks()
 

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -131,6 +131,31 @@ it('should wait for a shard to recover when all are lost', async () => {
   expect(channels[1].send).not.toHaveBeenCalled()
 })
 
+it('should pause when no shard is left to publish to', async () => {
+  channel = await create(connections, type)
+
+  const pause = /** @type {jest.MockedFunction} */ jest.fn()
+  const resume = /** @type {jest.MockedFunction} */ jest.fn()
+
+  channel.diagnose('pause', pause)
+  channel.diagnose('resume', resume)
+
+  lose(connections[0])
+
+  // the other shard is still reachable
+  expect(pause).not.toHaveBeenCalled()
+
+  lose(connections[1])
+
+  expect(pause).toHaveBeenCalledTimes(1)
+  expect(resume).not.toHaveBeenCalled()
+
+  restore(connections[1])
+
+  expect(resume).toHaveBeenCalledTimes(1)
+  expect(pause).toHaveBeenCalledTimes(1)
+})
+
 // a lost shard is not benched, so it is used again as soon as it reconnects
 it('should publish to a recovered shard', async () => {
   channel = await create(connections, type)
@@ -655,6 +680,34 @@ function emitReturn (channel, message) {
   expect(calls.length).toBeGreaterThan(0)
 
   for (const call of calls) call[1](message)
+}
+
+/**
+ * @param {jest.MockedObject<comq.Connection>} connection
+ * @param {Error} [error]
+ */
+function lose (connection, error) {
+  emit(connection, 'close', error)
+}
+
+/**
+ * @param {jest.MockedObject<comq.Connection>} connection
+ */
+function restore (connection) {
+  emit(connection, 'open')
+}
+
+/**
+ * @param {jest.MockedObject<comq.Connection>} connection
+ * @param {comq.diagnostics.Event} event
+ * @param {any[]} args
+ */
+function emit (connection, event, ...args) {
+  const calls = connection.diagnose.mock.calls.filter((call) => call[0] === event)
+
+  expect(calls.length).toBeGreaterThan(0)
+
+  for (const call of calls) call[1](...args)
 }
 
 /**


### PR DESCRIPTION
A connection that has gone silent — the socket open, the broker and the operating system saying nothing — is what a machine waking from sleep is left with. Every scenario in the suite loses a connection by stopping, killing or pausing a broker, and all three close the socket, so nothing covered it. Which is how the watchdog meant to handle it went a month without working.

## The watchdog told no one

It destroyed the silent socket without an error, and amqplib listens for `error` and `end` on it only. A bare `destroy()` emits neither: no `close`, no reconnection, and everything pending on that socket — topology recovery included — hanging forever, which left `#opening` pending and turned every later `open()` into a no-op.

Measured against a real broker behind a tunnel that stops forwarding:

| | before | after |
|---|---|---|
| watchdog set to 5s | nothing within 60s; 180s at best, and only because amqplib's own heartbeat eventually noticed | `close` → `reconnect` → `open` in 4s |
| no overrides at all | 180s | 45s |
| pending `createChannel` on a dead socket | never settles | rejected at once |
| `#drop` + amqplib's heartbeater | `UNCAUGHT EXCEPTION: Heartbeat timeout` | nothing, an error sink is left behind |

## A heartbeat worth measuring against

amqplib reads the heartbeat from the URL only, and comq asked for none, so RabbitMQ's suggestion of 60 seconds stood, leaving a lost connection unnoticed for minutes. A 15 second heartbeat is requested unless the URL sets one, and the socket is kept alive so the kernel has its own say. The watchdog, which measures silence, is derived from what was negotiated rather than fixed at 60 seconds — too long for a brisk heartbeat, and short enough to kill healthy idle connections on a broker that speaks less often than that.

## A pool with nowhere left to publish

`pause` and `resume` counted the channels benched for rejecting a publish, while `#one` picks from the shards that are reachable, which a lost connection deliberately leaves in the pool. Every shard going down at once therefore stalled every publish without a word. Both causes are reported the same way now.

`remove` was documented but missing from the events `IO` forwards, so `io.diagnose('remove')` never fired; `return` was forwarded but undocumented.

## A reply that could not be routed

A reply queue is exclusive, so the broker deletes it with the connection that declared it. Channels recover in creation order, request first: it resumes consuming, and a request published the moment it does is answered into a queue that does not exist yet. The reply comes back unroutable, is reported and dropped, and the caller — with no timeout to save it — waits forever. Retransmission follows the reply channel's recovery as well now, which closes the window in either order, including the one that matters in production, where producer and consumer recover as separate processes.

## A listener that throws

`#open` emits `reconnect` and `open` outside of any try/catch over a plain EventEmitter, so an exception from a listener took the reconnection down with it, permanently. Listeners are called one by one now, and an exception stops at the listener that threw.

## Tests

`features/silence.feature` reproduces the real thing with a TCP tunnel that goes silent while still accepting the connections that follow. It is not tagged `@heavy`, so it runs on every push. Its four scenarios, the new one in `recovery.feature`, and the new unit tests all fail against `dev`.

- `npm test` — 366 tests, green
- `npm run features` — 54 scenarios, 356 steps, green
- the amqplib mock now models what amqplib actually observes, so a socket destroyed without an error is as silent in the tests as it is in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)