### PR TITLE
fix: restore a singleton connection that was lost

### DIFF
--- a/features/connection.feature
+++ b/features/connection.feature
@@ -18,6 +18,20 @@ Feature: Connection Tolerance
     When the broker is up
     Then the connection is restored
 
+  Scenario: Restoring singleton connection after broker restart
+    Given an active singleton connection
+    When the broker is down
+    Then the connection is lost
+    When the broker is up
+    Then the connection is restored
+
+  Scenario: Restoring sharded singleton connection after broker crash
+    Given an active sharded singleton connection
+    When the broker has crashed
+    Then the connection is lost
+    When the broker is up
+    Then the connection is restored
+
   Scenario: Connecting with wrong credentials
     When I attempt to connect to the broker as "someone" with password "whatever"
     Then an exception is thrown: "Handshake terminated by server: 403 (ACCESS-REFUSED)"

--- a/features/silence.feature
+++ b/features/silence.feature
@@ -24,6 +24,22 @@ Feature: Silent Connection Tolerance
     When the consumer sends a request to the `echo` queue
     Then the consumer receives the reply
 
+  Scenario: Restoring a singleton connection that has gone silent
+    Given an active singleton connection
+    And a producer replying `echo` queue
+    When the network goes silent
+    Then the connection is lost within 10 seconds
+    When the consumer sends a request to the `echo` queue
+    Then the consumer receives the reply
+
+  Scenario: Restoring a sharded singleton connection whose every shard has gone silent
+    Given an active sharded singleton connection
+    And a producer replying `echo` queue
+    When the network goes silent
+    Then the connection is lost within 10 seconds
+    When the consumer sends a request to the `echo` queue
+    Then the consumer receives the reply
+
   Scenario: Answering a request sent as the connection goes silent
     Given an active connection to the broker
     And a producer replying `echo` queue

--- a/source/connection.js
+++ b/source/connection.js
@@ -64,16 +64,9 @@ class Connection {
   async open () {
     this.#closed = false
 
-    if (this.#opening !== null) return this.#opening
-
-    this.#opening = retry(this.#open).finally(() => { this.#opening = null })
-
-    await this.#opening
+    await this.#reopen()
 
     if (this.#closed) return
-
-    // close may have landed after this attempt succeeded but before `#opening` was cleared
-    if (this.#connection === undefined) return this.open()
 
     this.#running = true
   }
@@ -172,8 +165,27 @@ class Connection {
     this.#connection = undefined
 
     if (error !== undefined && !this.#closed) {
-      this.open().catch((exception) => this.#diagnostics.emit('error', exception))
+      this.#reopen().catch((exception) => this.#diagnostics.emit('error', exception))
     }
+  }
+
+  /**
+   * Establishes the connection, or joins the attempt under way. A lost connection is
+   * restored through here and not through `open()`: what a subclass makes of `open()` is
+   * its own — the singleton answers it with the first opening, made once and remembered,
+   * which is no way to make a second one.
+   *
+   * @return {Promise<void>}
+   */
+  async #reopen () {
+    this.#opening ??= retry(this.#open).finally(() => { this.#opening = null })
+
+    await this.#opening
+
+    if (this.#closed) return
+
+    // close may have landed after this attempt succeeded but before `#opening` was cleared
+    if (this.#connection === undefined) return this.#reopen()
   }
 
   /**

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -184,7 +184,7 @@ describe('reconnection', () => {
 
     const boom = new Error('reconnect failed')
 
-    connection.open = jest.fn(async () => { throw boom })
+    amqplib.connect.mockRejectedValueOnce(boom)
 
     conn.emit('close', new Error('broker down'))
 
@@ -195,6 +195,33 @@ describe('reconnection', () => {
     expect(errors).toContain(boom)
     expect(unhandled).not.toHaveBeenCalled()
   })
+
+  // the singleton answers `open()` with the first opening, made once and remembered
+  it('should reconnect a connection whose open() is remembered', async () => {
+    class Remembered extends Connection {
+      #opened = null
+
+      async open () {
+        this.#opened ??= super.open()
+
+        await this.#opened
+      }
+    }
+
+    const remembered = new Remembered(generate())
+
+    await remembered.open()
+
+    const first = await amqplib.connect.mock.results.at(-1).value
+
+    first.emit('close', new Error('lost'))
+
+    await expect(remembered.createChannel('event')).resolves.toBeDefined()
+
+    expect(amqplib.connect).toHaveBeenCalledTimes(3)
+
+    await remembered.close()
+  }, 10000)
 
   it('should reconnect when connection is lost while channels recover', async () => {
     const channel = await connection.createChannel('request')


### PR DESCRIPTION
## Summary

A lost connection restored itself by calling the public `open()`, and `SingletonConnection.open()` answers with the first opening it remembers — so a singleton connection, once lost, stayed lost: no attempt, no `reconnect` event, `#recovery` pending forever. Toa opens every connection with `assert()`, so none of the recovery fixes since August reached it: they were right, and every scenario that loses a connection opens it with `connect()`.

- `Connection` restores itself through a private `#reopen()`, which `open()` uses as well; what a subclass makes of `open()` no longer matters to recovery
- a reconnection no longer increments the singleton's reference count, so `close()` reaches zero again
- a unit test with a subclass whose `open()` is remembered fails on the previous code and passes now
- singleton and sharded singleton scenarios in `silence.feature` (network goes silent) and `connection.feature` (broker down, broker crashed)

Reproduced against a real broker closing the connection through the management API: `connect()` logged close → reconnect → open → recover within milliseconds and answered a request; `assert()` logged close and nothing else, and the request hung.

## Test plan

- [x] `npm test` — standard, 380 jest tests
- [x] `npm run features:fast` — 33 scenarios
- [x] `npx cucumber-js features/connection.feature` (`@heavy`) — 6 scenarios, including the two new singleton ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)
