### PR TITLE
test: close the connection whose reconnection was made to fail

### DIFF
--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -194,6 +194,9 @@ describe('reconnection', () => {
 
     expect(errors).toContain(boom)
     expect(unhandled).not.toHaveBeenCalled()
+
+    // the attempt is retried in the background, and would connect in a later case
+    await connection.close()
   })
 
   // the singleton answers `open()` with the first opening, made once and remembered


### PR DESCRIPTION
The release run of #261 failed on `should reconnect when connection is lost while channels recover`: four connections instead of three. The case before it makes a reconnection fail and leaves the attempt to be retried in the background, which connected a second later, in whichever case was running by then. The connection is now closed at the end of that case, which waits for the retry to see it and stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)