### PR TITLE
fix: memory leaks, unbounded buffering and the cost of a request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@testcontainers/rabbitmq": "^12.1.0",
         "@types/amqplib": "^0.10.8",
         "@types/jest": "^30.0.0",
-        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-conventionalcommits": "^10.4.0",
         "fast-glob": "^3.3.3",
         "fuzzysort": "4.0.2",
         "husky": "^9.1.7",
@@ -620,6 +620,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conventional-changelog/template": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
+      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@cucumber/ci-environment": {
@@ -4554,16 +4564,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -366,13 +366,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -408,13 +408,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -534,13 +534,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1262,17 +1262,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
-      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.5.0.tgz",
+      "integrity": "sha512-BI1DpOedrJqbrYVi9yNhDWGjqphR/+gsM4STmg2+VaeXm7851hvpBDyKOZGMXATTrGEnFuEseQvLCtrrRmG0GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
+        "jest-message-util": "30.5.0",
+        "jest-util": "30.5.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1280,18 +1280,18 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
-      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.5.0.tgz",
+      "integrity": "sha512-DLjRME+NY//j+UDTSfWnjoP0srrdR3DrJRy7yFZktGIwzpN2iVy2vMo0jziZ5c2Ij7bOwlJRXKVWtxZusazOJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/pattern": "30.4.0",
-        "@jest/reporters": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/console": "30.5.0",
+        "@jest/pattern": "30.5.0",
+        "@jest/reporters": "30.5.0",
+        "@jest/test-result": "30.5.0",
+        "@jest/transform": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
@@ -1299,20 +1299,20 @@
         "exit-x": "^0.2.2",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.4.1",
-        "jest-config": "30.4.2",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-resolve-dependencies": "30.4.2",
-        "jest-runner": "30.4.2",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "pretty-format": "30.4.1",
+        "jest-changed-files": "30.5.0",
+        "jest-config": "30.5.0",
+        "jest-haste-map": "30.5.0",
+        "jest-message-util": "30.5.0",
+        "jest-regex-util": "30.5.0",
+        "jest-resolve": "30.5.0",
+        "jest-resolve-dependencies": "30.5.0",
+        "jest-runner": "30.5.0",
+        "jest-runtime": "30.5.0",
+        "jest-snapshot": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-validate": "30.5.0",
+        "jest-watcher": "30.5.0",
+        "pretty-format": "30.5.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.5.0.tgz",
+      "integrity": "sha512-OsqBjHXCn8cadasoAZBP6nWYvMsRhpMzGXTpxJ5aO04NlbdhIz+FVe3q49l0AwVhsz/cEmIpBes6gAFl1/dWQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1338,70 +1338,70 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.5.0.tgz",
+      "integrity": "sha512-HUaqexIauIh69IQ4NTuPDEUCB8g8T4TOPSIzQOS18mwI/KEHKQk1j013K2o6ra031szZE2t5jGmVx3xbzdjgKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/fake-timers": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
-        "jest-mock": "30.4.1"
+        "jest-mock": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.5.0.tgz",
+      "integrity": "sha512-jEmgmgJEobJ3zEhDOGp1VAJ6JkoVelpS8uZ1ae1Ul/5lP78UKJKmmU0lciJwd6JdnqOXHaaS/QCKwbf1dHI9MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.4.1",
-        "jest-snapshot": "30.4.1"
+        "expect": "30.5.0",
+        "jest-snapshot": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.5.0.tgz",
+      "integrity": "sha512-5j0ztPxSy3McUJihjkDdCyCfjvT2hxykFTWsgEBZKB8qsw9ALdCiGTpTRH5gnf/d+qI4SflYUJ0dWNbzjQCWbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.1.0"
+        "@jest/get-type": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.5.0.tgz",
+      "integrity": "sha512-sg8xIbYwe5GdB/vT3/0qrDIpO7Ov9mazHi++M95uynmDKEZ70G1r169AWct73H07VrTZhrz1SJEfLtjYv8tE3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.5.0",
         "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
+        "jest-message-util": "30.5.0",
+        "jest-mock": "30.5.0",
+        "jest-util": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.5.0.tgz",
+      "integrity": "sha512-9/2VUPitAjmBzbvDvqrxmvB7BzWsBW0WmkkojX1ODuxX1NLGxx9gfaZpHB0z8DtJ9uhGNmZG/VXBhf8uO0OV8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1409,62 +1409,78 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
-      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.5.0.tgz",
+      "integrity": "sha512-h7eJx534czwL8lQMYB0hwLT4/HquO8EX/RtYL7RNUHyUyWWVciYjoudN4Ns5JmNvn2/jh0Vm9UstZjEzJJ5EsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/types": "30.4.1",
-        "jest-mock": "30.4.1"
+        "@jest/environment": "30.5.0",
+        "@jest/expect": "30.5.0",
+        "@jest/types": "30.5.0",
+        "jest-mock": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.5.0.tgz",
+      "integrity": "sha512-HdNQYSdRTEBNrginaqzQtTjG0HRMfrra/z6Ok7uL3S87vSlarIVohEsJsSj5edu3MiHoHjAkvPROz5ZjoKai+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-regex-util": "30.4.0"
+        "jest-regex-util": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jest/reporters": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
-      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.5.0.tgz",
+      "integrity": "sha512-FEAuusWm+PUOn9ydjaHhpOpyPmS6IbGE04HaKTuUI4zd8eqYZiXiNLoCsdCog/l2XnNj53E9pFy64UltcvfJKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jest/console": "30.5.0",
+        "@jest/test-result": "30.5.0",
+        "@jest/transform": "30.5.0",
+        "@jest/types": "30.5.0",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "collect-v8-coverage": "^1.0.2",
         "exit-x": "^0.2.2",
-        "glob": "^10.5.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^6.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
+        "jest-message-util": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-worker": "30.5.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1481,10 +1497,94 @@
         }
       }
     },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.5.0.tgz",
+      "integrity": "sha512-/hunigyNpc4RCjC0VaW3f5RCUZVM2+WQ65qP7z083Gmvac7or2LI50XVNOtE4YPgBpV0yxYiAgorAPGniCoJmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1495,13 +1595,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
-      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.5.0.tgz",
+      "integrity": "sha512-iWQtIsi2dRsO2oWzVceOeynuRJiYTW8gsDVp5wFQ02ipHluQsNgBpasWSHiawVxukIlsGLdCtCSbIEK7fPtpvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.5.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -1511,14 +1611,15 @@
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
-      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.5.0.tgz",
+      "integrity": "sha512-xWpTJP9D0bDFGbPGT8XuWSwwha/iHADyyKzUnMx4UbdgnHugxrDaQFO4RZ8x4ZsFzRP6pNii8uvlgKCDxCIuDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "callsites": "^3.1.0",
+        "convert-source-map": "^2.0.0",
         "graceful-fs": "^4.2.11"
       },
       "engines": {
@@ -1526,14 +1627,14 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
-      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.5.0.tgz",
+      "integrity": "sha512-9IlPqUzUMkVDmoDqSSrVVLroVotgN3hTUPWPwq24XWXhh1Zpg915RXZ5pgRJ/7j4YE/kng5nqjSn4p3S68SZJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/console": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -1542,15 +1643,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
-      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.5.0.tgz",
+      "integrity": "sha512-TXlvSDIVv482b83hD8A8WtxDJEmGF47f60W6jRXOQL0Isfs3hKtk4rZIm9R/jLzAibg8+c56y+Q00BQs8R7Xcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.4.1",
+        "@jest/test-result": "30.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
+        "jest-haste-map": "30.5.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1558,23 +1659,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
-      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.5.0.tgz",
+      "integrity": "sha512-n1cYhoByyULEIXi64wbT4Lq91qeT1E6bwpM//sprFXhw955qaiHTdAmy1c1rNFGB6fCf1J+nxDUSf3RGwgZP5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
+        "@jest/types": "30.5.0",
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "babel-plugin-istanbul": "^8.0.0",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
+        "jest-haste-map": "30.5.0",
+        "jest-regex-util": "30.5.0",
+        "jest-util": "30.5.0",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
         "write-file-atomic": "^5.0.1"
@@ -1584,14 +1685,14 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.5.0.tgz",
+      "integrity": "sha512-s1N+79S4Yp9ZgklCauZXi+YPJdCdtStNYQT32stuD6EeQaIBGHoUfyj2P0YWy8RmuQfaJboO+ulxEvEheR/POQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
+        "@jest/pattern": "30.5.0",
+        "@jest/schemas": "30.5.0",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -1635,9 +1736,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1674,22 +1775,25 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1888,6 +1992,311 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1900,13 +2309,13 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
@@ -2615,9 +3024,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2939,6 +3348,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2953,6 +3365,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2967,6 +3382,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2981,6 +3399,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2995,6 +3416,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3009,6 +3433,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3023,6 +3450,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3037,6 +3467,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3051,6 +3484,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3065,6 +3501,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3658,16 +4097,16 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.5.0.tgz",
+      "integrity": "sha512-PrhPHlKC+MsLnuNzgIH/y1dkz1f6cSfKWaQeaG8WxLMuG44dYWQ8E9uRrsBbAGCU/3+BEFYPN4d6G3Zc5Y+waA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.4.1",
+        "@jest/transform": "30.5.0",
         "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.4.0",
+        "babel-plugin-istanbul": "^8.0.0",
+        "babel-preset-jest": "30.5.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -3680,9 +4119,9 @@
       }
     },
     "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-8.0.0.tgz",
+      "integrity": "sha512-18wCskrN3DgbuBmp1gr7LBGT8xdz5xhQQqFvFhVxbkl8VBCrMKQ2YtqBWtUal1Zrc1HTuX0011+Brjw78TCFkg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "workspaces": [
@@ -3693,16 +4132,16 @@
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-instrument": "^6.0.2",
-        "test-exclude": "^6.0.0"
+        "test-exclude": "^7.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.5.0.tgz",
+      "integrity": "sha512-gtGo1B+u14jrZQv6TdSWIWkTqclboo7Qn+dFAGUOIuXLFuJKAdg3U5MIWzZnW4vfUb4dX9skmAMiby86e/SF4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3740,20 +4179,20 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.5.0.tgz",
+      "integrity": "sha512-ZGPn5ClP4lBDpuOK8W1yQIOy359HmbnZv3suucAlIe+SEE9yDsxV4S2PjSbH2Vc97U+WmzYD7vw3kr8NsQ/i6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.4.0",
+        "babel-plugin-jest-hoist": "30.5.0",
         "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1 || ^8.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4190,19 +4629,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -4237,9 +4663,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4953,6 +5379,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -5509,6 +5945,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -6401,18 +6844,18 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.5.0.tgz",
+      "integrity": "sha512-8fiMWcEjPU7B9nErC4FtFcCzf2tC6I75Qf7m8wzBAWC2taZmcno3yAFEjIQL34SwoGZNgPf63UDiJLyh4SMPaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
+        "@jest/expect-utils": "30.5.0",
+        "@jest/get-type": "30.5.0",
+        "jest-matcher-utils": "30.5.0",
+        "jest-message-util": "30.5.0",
+        "jest-mock": "30.5.0",
+        "jest-util": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6700,21 +7143,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -8068,19 +8496,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-report/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/istanbul-lib-source-maps": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
@@ -8155,16 +8570,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
-      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.5.0.tgz",
+      "integrity": "sha512-HeFeOUEKh5gjnp1rjuSCse8Dhj0Y3KA8lsZ3azr4Wnq1nCxwMBu35MDc9mp8iblZxmeAz6wV4P241tyUB7J2Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/types": "30.4.1",
+        "@jest/core": "30.5.0",
+        "@jest/types": "30.5.0",
         "import-local": "^3.2.0",
-        "jest-cli": "30.4.2"
+        "jest-cli": "30.5.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -8182,14 +8597,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
-      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.5.0.tgz",
+      "integrity": "sha512-dq1x8JiEnHkJDxxOrF6UJDivBRAQMwAa5tzr+VX3um0SfyMFseUPQUbe51wLwggfoa5h/EmOtSpdJxxkzSlNRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.4.1",
+        "jest-util": "30.5.0",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -8197,29 +8612,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
-      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.5.0.tgz",
+      "integrity": "sha512-T3v7uM4wwCu+RQicjsAWCgoL3CiyuX3THSKwv2uMb9N2bMUgb+HfwDWEUma85vOGbvQNQ/YfoCXF1OCZot0ZEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/environment": "30.5.0",
+        "@jest/expect": "30.5.0",
+        "@jest/test-result": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
+        "jest-each": "30.5.0",
+        "jest-matcher-utils": "30.5.0",
+        "jest-message-util": "30.5.0",
+        "jest-runtime": "30.5.0",
+        "jest-snapshot": "30.5.0",
+        "jest-util": "30.5.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.4.1",
+        "pretty-format": "30.5.0",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -8229,21 +8644,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
-      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.5.0.tgz",
+      "integrity": "sha512-QHZMiy32x2K+NzJ1AuuoCAVc1Y5co0VXib3R7kD9MWcWFflzsD1eJN0wR+mkNlM+ts7C+Bjz0oOoFE5IiHylCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/core": "30.5.0",
+        "@jest/test-result": "30.5.0",
+        "@jest/types": "30.5.0",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
+        "jest-config": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-validate": "30.5.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -8262,33 +8677,33 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
-      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.5.0.tgz",
+      "integrity": "sha512-gYQl2FqYgiVpyuB7DutBIbJRWaq5VcHdzOXJJ51HNa8J5JrsZehIlzNFW0/9s5uvvcbzM5/LTUizYSbsFErv+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.4.0",
-        "@jest/test-sequencer": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-jest": "30.4.1",
+        "@jest/get-type": "30.5.0",
+        "@jest/pattern": "30.5.0",
+        "@jest/test-sequencer": "30.5.0",
+        "@jest/types": "30.5.0",
+        "babel-jest": "30.5.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
-        "glob": "^10.5.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.2",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-runner": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
+        "jest-circus": "30.5.0",
+        "jest-docblock": "30.5.0",
+        "jest-environment-node": "30.5.0",
+        "jest-regex-util": "30.5.0",
+        "jest-resolve": "30.5.0",
+        "jest-runner": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-validate": "30.5.0",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.4.1",
+        "pretty-format": "30.5.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -8312,26 +8727,110 @@
         }
       }
     },
-    "node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.5.0.tgz",
+      "integrity": "sha512-QjCfDMwdPFvLxTQmS4/Dswx3PUCiqmSXVLGljMC3SU7YG1qHVoR6b86IH/O2G9k9OMyKXz2vS2Q60VnAozNDwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.5.0",
+        "@jest/get-type": "30.5.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
+        "pretty-format": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
-      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.5.0.tgz",
+      "integrity": "sha512-NwDqcxtoZi33RhuW+zJS/RVA3rmheQ8BnwpYZuc/Eruaz6seQb7+aoCeDZu/3X7W2XmD8DbSo9Pn72DbKsBFYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8342,111 +8841,109 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
-      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.5.0.tgz",
+      "integrity": "sha512-NiMFNhRygJEFqYNt8pnkxppUF6CR486GEpt9rSU6lPBf7KeccaOL0zbjxG8fgJgD//6e7zYdssnlt6j+1kI31A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
+        "@jest/get-type": "30.5.0",
+        "@jest/types": "30.5.0",
         "chalk": "^4.1.2",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1"
+        "jest-util": "30.5.0",
+        "pretty-format": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.5.0.tgz",
+      "integrity": "sha512-bTc79ywKLz0ogbT3JIYuEhgWV4Ffd/cJe06co4v8CyRtlmju8x5gokMlGFR8ARWhmk5SnbDRxmf50XWnlZVhDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/environment": "30.5.0",
+        "@jest/fake-timers": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1"
+        "jest-mock": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-validate": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
-      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.5.0.tgz",
+      "integrity": "sha512-0FStogBslBVOEqTOJr4oXMtFitmrWp9WscG6Gbns88i0YAuMXijCT2G5VMfg/HCR4QAnL+OF2C2ednag+HlDuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.5.0",
+        "@parcel/watcher": "^2.6.0",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
+        "fdir": "^6.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "picomatch": "^4.0.3",
-        "walker": "^1.0.8"
+        "jest-regex-util": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-worker": "30.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
-      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.5.0.tgz",
+      "integrity": "sha512-Mq11ceAkNR250Iv45RoOwuG9fb4kYbJ02qoyL7A0nCI8FV5+aG/THmcEUx5uR2dNSa4KOtz+xBKrJ8cZPhPpuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "pretty-format": "30.4.1"
+        "@jest/get-type": "30.5.0",
+        "pretty-format": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.5.0.tgz",
+      "integrity": "sha512-EfaYMC9f9ds7fahB/LYFTgd1Z2RS9Vpm2e46gazij0onkpoQG7Daq+MLm8/gQVqWwRVjL/RNDggbFx9MsrJEmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.1.0",
+        "@jest/get-type": "30.5.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
+        "jest-diff": "30.5.0",
+        "pretty-format": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.5.0.tgz",
+      "integrity": "sha512-dBYMhplGfspKaCnVk9TUy1cZnknWubpuPNEputjz0YJk1G/92R45rn45BvbPMPMtC5LVcIdxJGPOaOSQTiuzJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.5.0",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
+        "jest-util": "30.5.0",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
+        "pretty-format": "30.5.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -8455,42 +8952,25 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.5.0.tgz",
+      "integrity": "sha512-bP5MHZpkYrV7xpV+yvhl36DPcXoEmTR57Un5EACcdVpMY7mpkDefCBq+V4mhcjE/3rwUajT6OTrcJTN7EwN1BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/expect-utils": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
-        "jest-util": "30.4.1"
+        "jest-util": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.5.0.tgz",
+      "integrity": "sha512-Mg0WK7A6xRHLSA1udJ8y9f3lM0uUhFTBnLKzwPmqB9AylvpleJ6BLemR8K9dK27DY+cesDryoA7yLZCAHsPG1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8498,111 +8978,100 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
-      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.5.0.tgz",
+      "integrity": "sha512-NFvQWJ4G7e2kN5712iG+12Xr325NRFGAIhovrwLfgq5Oqd4bFHITw4CzcFkZGp1GTCqemC4v1l8/yZzedKZkjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
+        "jest-haste-map": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-validate": "30.5.0",
         "slash": "^3.0.0",
-        "unrs-resolver": "^1.7.11"
+        "unrs-resolver": "^1.12.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
-      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.5.0.tgz",
+      "integrity": "sha512-TnSBAp3wGOnqXBmLT3OXtJkugw6Vj2KU0IPde2EJmbGns/QMoNlkauJ7jZ8KYaxONSpx0o4pUvi+u1Q/LSk3Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-regex-util": "30.4.0",
-        "jest-snapshot": "30.4.1"
+        "jest-regex-util": "30.5.0",
+        "jest-snapshot": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
-      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.5.0.tgz",
+      "integrity": "sha512-Q6Yt+1LvXvEstvru6sQLT7OQYC77VNl6dK0KEvBkeOHgThmXDqNp3Ox9TglDWFHU85pemqTNdKwxfnmO3vgrdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/environment": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/console": "30.5.0",
+        "@jest/environment": "30.5.0",
+        "@jest/source-map": "30.5.0",
+        "@jest/test-result": "30.5.0",
+        "@jest/transform": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-haste-map": "30.4.1",
-        "jest-leak-detector": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-resolve": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "jest-worker": "30.4.1",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
+        "jest-docblock": "30.5.0",
+        "jest-environment-node": "30.5.0",
+        "jest-haste-map": "30.5.0",
+        "jest-leak-detector": "30.5.0",
+        "jest-message-util": "30.5.0",
+        "jest-resolve": "30.5.0",
+        "jest-runtime": "30.5.0",
+        "jest-util": "30.5.0",
+        "jest-watcher": "30.5.0",
+        "jest-worker": "30.5.0",
+        "p-limit": "^3.1.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/jest-runtime": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
-      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.5.0.tgz",
+      "integrity": "sha512-VTRz0sRIw2EISeHigx1O+CMuwoG4+RKJjF8dp8okzFaDNQEcv5Mw0h5QW8VJXgb2CRF4gZIjSEBb2jdzXPagFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/globals": "30.4.1",
-        "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/environment": "30.5.0",
+        "@jest/fake-timers": "30.5.0",
+        "@jest/globals": "30.5.0",
+        "@jest/source-map": "30.5.0",
+        "@jest/test-result": "30.5.0",
+        "@jest/transform": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "cjs-module-lexer": "^2.1.0",
+        "cjs-module-lexer": "^2.2.0",
         "collect-v8-coverage": "^1.0.2",
-        "glob": "^10.5.0",
+        "es-module-lexer": "^2.1.0",
+        "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
+        "jest-haste-map": "30.5.0",
+        "jest-message-util": "30.5.0",
+        "jest-mock": "30.5.0",
+        "jest-regex-util": "30.5.0",
+        "jest-resolve": "30.5.0",
+        "jest-snapshot": "30.5.0",
+        "jest-util": "30.5.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -8610,10 +9079,94 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jest-snapshot": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
-      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.5.0.tgz",
+      "integrity": "sha512-pZWETdcqmKve9MDTE/AX6RaeAbRhzKhhAXGozAW8Pg2FfOSdUrQ/7D+VdwE3fLQsqjpITXJVQvYVZoMEzrUl0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8622,20 +9175,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/expect-utils": "30.5.0",
+        "@jest/get-type": "30.5.0",
+        "@jest/snapshot-utils": "30.5.0",
+        "@jest/transform": "30.5.0",
+        "@jest/types": "30.5.0",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.4.1",
+        "expect": "30.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1",
+        "jest-diff": "30.5.0",
+        "jest-matcher-utils": "30.5.0",
+        "jest-message-util": "30.5.0",
+        "jest-util": "30.5.0",
+        "pretty-format": "30.5.0",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -8644,13 +9197,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.5.0.tgz",
+      "integrity": "sha512-lzU4aGUWaS+2X/B0CmgheDasfnsVlRfZh/rNQxB9b9s8cSYUq5BcqdQA95ld+KqJXBUVVt1sqnMQ2T3OxIalmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.4.1",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -8662,18 +9215,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
-      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.5.0.tgz",
+      "integrity": "sha512-N/hsPYKgBSzBeVZ2RHCs3yvBbTZNPX7Be8q33zhyo/yeFneBL1swzly31LYU4LJ3zJM9e8TxSM8IYLo2SDJZYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
+        "@jest/get-type": "30.5.0",
+        "@jest/types": "30.5.0",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.4.1"
+        "pretty-format": "30.5.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8693,19 +9246,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
-      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.5.0.tgz",
+      "integrity": "sha512-ujjnEoL4Uu+Swu3WRwYenWMB9JMEiD2T3OypnveMJ64S/1r/5G8eC4OQ1wEOgYWQqMi+mT+buzccflCHr/XJ9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
+        "@jest/test-result": "30.5.0",
+        "@jest/types": "30.5.0",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.4.1",
+        "jest-util": "30.5.0",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -8713,20 +9266,36 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
-      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.5.0.tgz",
+      "integrity": "sha512-7kFk/607EoynNHLJa20daivkElM+c9PrCLduYy6AlMkYrXbh5TmVtW1BLXE05Y8baAFsJHMoC3xs2QRRTotwLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.4.1",
+        "jest-util": "30.5.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-tokens": {
@@ -9175,16 +9744,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/makeerror": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tmpl": "1.0.5"
-      }
-    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -9462,6 +10021,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12123,16 +12689,16 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "version": "30.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.5.0.tgz",
+      "integrity": "sha512-mzNzBErpHwM0zpmWS7ExOv62yhQhvd546nUuFqVR0dmnJB59tfrw9sjDF0DJknwsr59OXP0buwJ7PaKguczHSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
+        "@jest/react-is-18": "npm:react-is@^18.3.1",
+        "@jest/react-is-19": "npm:react-is@^19.2.5",
+        "@jest/schemas": "30.5.0",
+        "ansi-styles": "^5.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -12404,22 +12970,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/read-package-up": {
       "version": "12.0.0",
@@ -14257,19 +14807,16 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/supports-hyperlinks": {
@@ -14289,19 +14836,6 @@
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
       }
     },
-    "node_modules/supports-hyperlinks/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -14316,13 +14850,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -14438,64 +14972,57 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "20 || >=22"
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/testcontainers": {
@@ -14675,13 +15202,6 @@
       "engines": {
         "node": ">=14.14"
       }
-    },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -15155,16 +15675,6 @@
       "license": "0BSD",
       "engines": {
         "node": ">=0.10.48"
-      }
-    },
-    "node_modules/walker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "makeerror": "1.0.12"
       }
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@testcontainers/rabbitmq": "^12.1.0",
     "@types/amqplib": "^0.10.8",
     "@types/jest": "^30.0.0",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^10.4.0",
     "fast-glob": "^3.3.3",
     "fuzzysort": "4.0.2",
     "husky": "^9.1.7",

--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,11 @@ These intervals are not configurable.
 
 An "end stream" message is sent to the `replyTo` queue when the Reply stream is finished.
 
+When the Consumer falls behind, a "pause" message is sent to the Producer's control queue,
+and the Producer stops pulling values from the iterator until a "resume" message follows.
+The Producer announces its support of these messages in the confirmation message,
+so they are never sent to a Producer that would not understand them.
+
 See also [Reply stream shutdown](#reply-stream-shutdown).
 
 ### Loss of tail
@@ -278,7 +283,8 @@ At the same time, there is no guarantee that the stream will be transmitted to t
 
 > When using the [Sharded connection](#sharded-connection), the order of yielded values is maintained through buffering.
 > However, there is a scenario in which some of the yielded values may be lost if a broker crashes.
-> In this case, the Reply stream will be destroyed once the buffer's maximum size is exceeded.
+> In this case, the Reply stream will be destroyed once the buffer's maximum size is exceeded
+> (1000 values or 16 MiB of encoded messages).
 > Also, buffered control messages can result in [stream idling](#stream-control).
 
 ## Encoding

--- a/source/.io/ReplyPipe.js
+++ b/source/.io/ReplyPipe.js
@@ -1,17 +1,22 @@
 'use strict'
 
 const { EventEmitter } = require('node:events')
-const { control, HEARTBEAT_INTERVAL } = require('./const')
+const { Promex } = require('promex')
+const { control, FLOW_HEADER, HEARTBEAT_INTERVAL } = require('./const')
 
 /** @typedef {(message: any, properties?: comq.amqp.options.Publish) => Promise<void>} Reply */
 
 class ReplyPipe extends EventEmitter {
   #index = -1
   #interrupted = false
+  #closed = false
   #heartbeatInterval = global['COMQ_TESTING_HEARTBEAT_INTERVAL'] || HEARTBEAT_INTERVAL
 
   /** @type {ReturnType<setInterval> | null} */
   #interval = null
+
+  /** Closed while the consumer has asked for a pause. */
+  #gate = null
 
   /** @type {string} */
   #replyTo
@@ -51,7 +56,8 @@ class ReplyPipe extends EventEmitter {
 
     this.#properties = {
       chunk: { correlationId, ...CHUNK },
-      control: { correlationId, replyTo: feedback.queue, ...CONTROL }
+      control: { correlationId, replyTo: feedback.queue, ...CONTROL },
+      ok: { correlationId, replyTo: feedback.queue, ...CONTROL, headers: FLOW }
     }
 
     channel.diagnose('return', this.#onReturn)
@@ -59,11 +65,13 @@ class ReplyPipe extends EventEmitter {
   }
 
   async pipe () {
-    await this.#transmit(control.ok, this.#properties.control)
+    await this.#transmit(control.ok, this.#properties.ok)
 
-    this.#stream.on('data', this.#onData)
-    this.#stream.on('close', this.#close)
+    if (this.#closed) return
+
     this.#heartbeat()
+
+    void this.#pump()
   }
 
   destroy () {
@@ -71,11 +79,35 @@ class ReplyPipe extends EventEmitter {
     this.#stream.destroy()
   }
 
+  /**
+   * The source is pulled rather than listened to: a value is asked for once the
+   * previous one has been handed to the channel, so a paused channel or a paused
+   * consumer holds the source back instead of piling its output up here.
+   */
+  async #pump () {
+    try {
+      for await (const chunk of this.#stream) {
+        if (this.#gate !== null) await this.#gate
+        if (this.#closed) break
+
+        await this.#transmit(chunk, this.#properties.chunk)
+
+        if (this.#closed) break
+
+        this.#heartbeat()
+      }
+    } catch {
+      // the source has been destroyed, by this pipe or by whoever made it
+    }
+
+    this.#close()
+  }
+
   async #transmit (data, properties) {
     this.#index++
 
-    const ok = await this.#reply(data,
-      { ...properties, headers: { index: this.#index } })
+    const headers = { ...properties.headers, index: this.#index }
+    const ok = await this.#reply(data, { ...properties, headers })
 
     if (!ok) this.#interrupt()
   }
@@ -97,24 +129,27 @@ class ReplyPipe extends EventEmitter {
   #clear () {
     clearInterval(this.#interval)
 
-    this.#stream.removeAllListeners()
     this.#channel.forget('return', this.#onReturn)
     this.#feedback.off(this.#properties.control.correlationId, this.#control)
+    this.#resume()
+  }
+
+  #resume () {
+    this.#gate?.resolve()
+    this.#gate = null
   }
 
   #close = () => {
+    if (this.#closed) return
+
+    this.#closed = true
+
     this.emit('close')
     this.#clear()
 
     if (!this.#interrupted) {
       void this.#transmit(control.end, this.#properties.control)
     }
-  }
-
-  #onData = async (chunk) => {
-    await this.#transmit(chunk, this.#properties.chunk)
-
-    this.#heartbeat()
   }
 
   #onReturn = (message) => {
@@ -126,6 +161,12 @@ class ReplyPipe extends EventEmitter {
     switch (message) {
       case control.end:
         this.#interrupt()
+        break
+      case control.pause:
+        this.#gate ??= new Promex()
+        break
+      case control.resume:
+        this.#resume()
         break
       default:
         throw new Error(`Unknown control message: ${message}`)
@@ -154,5 +195,7 @@ const CHUNK = { mandatory: true }
 
 /** @type {comq.amqp.options.Publish} */
 const CONTROL = { type: 'control', mandatory: true }
+
+const FLOW = { [FLOW_HEADER]: true }
 
 exports.ReplyPipe = ReplyPipe

--- a/source/.io/ReplyStream.js
+++ b/source/.io/ReplyStream.js
@@ -2,7 +2,7 @@
 
 const { Readable } = require('node:stream')
 const { Promex } = require('promex')
-const { IDLE_INTERVAL, control } = require('./const')
+const { IDLE_INTERVAL, FLOW_HEADER, control } = require('./const')
 
 class ReplyStream extends Readable {
   confirmation = new Promex()
@@ -16,6 +16,7 @@ class ReplyStream extends Readable {
   /** @type {string} */
   #correlationId
 
+  /** The confirmation message, addressing the control queue of the producer. */
   #control
 
   #reply
@@ -26,9 +27,19 @@ class ReplyStream extends Readable {
 
   #buffered = 0
 
+  #bufferedBytes = 0
+
   #maxBufferSize
 
-  /** @type {Map<number, unknown>} */
+  #maxBufferBytes
+
+  /** Whether the producer honours `pause` and `resume`. */
+  #flow = false
+
+  /** Whether the producer has been asked to pause. */
+  #throttled = false
+
+  /** @type {Map<number, { payload: unknown, properties: comq.amqp.Properties, size: number }>} */
   #queue = new Map()
 
   /**
@@ -42,6 +53,7 @@ class ReplyStream extends Readable {
     this.#correlationId = request.properties.correlationId
     this.#idleInterval = global['COMQ_TESTING_IDLE_INTERVAL'] || IDLE_INTERVAL
     this.#maxBufferSize = global['COMQ_TESTING_MAX_BUFFER_SIZE'] || MAX_BUFFER_SIZE
+    this.#maxBufferBytes = global['COMQ_TESTING_MAX_BUFFER_BYTES'] || MAX_BUFFER_BYTES
     this.#reply = reply
 
     this.confirmation.catch(noop) // it is not awaited until the stream is handed over
@@ -65,15 +77,25 @@ class ReplyStream extends Readable {
     super._destroy(error, callback)
   }
 
-  _read (_) {}
+  /**
+   * Called once the consumer has room again.
+   */
+  _read (_) {
+    if (!this.#throttled) return
+
+    this.#throttled = false
+
+    void this.#reply(this.#control, control.resume)
+  }
 
   /**
    * @param {unknown} payload
    * @param {comq.amqp.Properties} properties
+   * @param {number} [size] of the encoded payload
    */
-  arrange (payload, properties) {
+  arrange (payload, properties, size = 0) {
     if (properties.headers.index !== this.#index) {
-      this._buffer(payload, properties)
+      this._buffer(payload, properties, size)
 
       return
     }
@@ -85,6 +107,7 @@ class ReplyStream extends Readable {
 
       while ((message = this.#queue.get(this.#index))) {
         this.#queue.delete(this.#index)
+        this.#bufferedBytes -= message.size
         this._add(message.payload, message.properties)
       }
 
@@ -104,18 +127,45 @@ class ReplyStream extends Readable {
     if (properties.type === 'control')
       this._control(payload, properties)
     else if (!this.push(payload))
-      this._clear()
+      this._throttle()
   }
 
-  _buffer (payload, properties) {
-    if (this.#buffered > this.#maxBufferSize) {
+  /**
+   * Values arriving out of order are held until the gap is filled. The hold is
+   * bounded by their number and, roughly, by their size: the size is that of
+   * the encoded message, which is what is known of a decoded value.
+   *
+   * @param {unknown} payload
+   * @param {comq.amqp.Properties} properties
+   * @param {number} size
+   * @private
+   */
+  _buffer (payload, properties, size) {
+    if (this.#buffered > this.#maxBufferSize || this.#bufferedBytes + size > this.#maxBufferBytes) {
       this.destroy()
 
       return
     }
 
     this.#buffered++
-    this.#queue.set(properties.headers.index, { payload, properties })
+    this.#bufferedBytes += size
+    this.#queue.set(properties.headers.index, { payload, properties, size })
+  }
+
+  /**
+   * The consumer is behind. Values in flight keep coming, and a producer that
+   * knows nothing of `pause` keeps going, in which case they pile up here rather
+   * than get lost: dropping the listener would leave the stream waiting for a
+   * value that has already passed.
+   *
+   * @private
+   */
+  _throttle () {
+    if (this.#throttled || !this.#flow) return
+
+    this.#throttled = true
+
+    void this.#reply(this.#control, control.pause)
   }
 
   /**
@@ -127,6 +177,7 @@ class ReplyStream extends Readable {
     switch (message) {
       case control.ok:
         this.#control = { properties }
+        this.#flow = properties.headers?.[FLOW_HEADER] === true
         this.confirmation.resolve()
         break
       case control.heartbeat:
@@ -147,11 +198,14 @@ class ReplyStream extends Readable {
 
   _clear () {
     clearTimeout(this.#timeout)
-    this.#emitter.removeAllListeners(this.#correlationId)
+    this.#emitter.off(this.#correlationId)
   }
 }
 
 const MAX_BUFFER_SIZE = 1000
+
+/** @type {number} */
+const MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
 const UNCONFIRMED = 'Reply stream has been destroyed before confirmation'
 

--- a/source/.io/const.js
+++ b/source/.io/const.js
@@ -3,8 +3,16 @@
 exports.control = {
   ok: 'ok',
   heartbeat: 'heartbeat',
-  end: 'end'
+  end: 'end',
+  pause: 'pause',
+  resume: 'resume'
 }
+
+/**
+ * Set on the confirmation message by a producer that honours `pause` and
+ * `resume`, so that a consumer never sends them to one that does not.
+ */
+exports.FLOW_HEADER = 'x-flow'
 
 exports.HEARTBEAT_INTERVAL = 5_000
 exports.IDLE_INTERVAL = 12_000

--- a/source/.io/createReplyEmitter.js
+++ b/source/.io/createReplyEmitter.js
@@ -1,22 +1,97 @@
 'use strict'
 
 const { randomBytes } = require('node:crypto')
-const { EventEmitter } = require('node:events')
 const { concat } = require('./concat')
+
+/**
+ * Routes the replies arriving on a queue to whoever is waiting for them.
+ *
+ * A Map keyed by correlation identifier rather than an EventEmitter: with
+ * thousands of requests in flight the emitter's event table degrades into a
+ * dictionary, and every `once` costs a wrapper.
+ *
+ * @implements {comq.ReplyEmitter}
+ */
+class ReplyEmitter {
+  /** @type {string} */
+  queue
+
+  /** @type {string} */
+  #prefix
+
+  /** @type {number} */
+  #sequence = 0
+
+  /** @type {Map<string, comq.ReplyHandler>} */
+  #handlers = new Map()
+
+  /**
+   * @param {string} label
+   */
+  constructor (label) {
+    const id = randomBytes(8).toString('hex')
+
+    this.queue = concat(label, id)
+    this.#prefix = id
+  }
+
+  /**
+   * A correlation identifier that is unique across processes as well: the
+   * control queue of a producer sees the requests of every consumer, and tells
+   * them apart by nothing else. Random bytes per request would cost more than
+   * everything else on the way to the broker put together.
+   *
+   * @return {string}
+   */
+  next () {
+    return this.#prefix + (++this.#sequence).toString(36)
+  }
+
+  /**
+   * @param {string} id
+   * @param {comq.ReplyHandler} handler
+   */
+  on (id, handler) {
+    this.#handlers.set(id, handler)
+  }
+
+  /**
+   * @param {string} id
+   * @param {comq.ReplyHandler} [handler] the one to remove, or whichever is there
+   */
+  off (id, handler) {
+    if (handler === undefined || this.#handlers.get(id) === handler) this.#handlers.delete(id)
+  }
+
+  /**
+   * @param {string} id
+   * @param {any} payload
+   * @param {comq.amqp.Properties} properties
+   * @param {number} [size] of the encoded payload
+   * @return {boolean} whether anyone was waiting
+   */
+  emit (id, payload, properties, size) {
+    const handler = this.#handlers.get(id)
+
+    if (handler === undefined) return false
+
+    handler(payload, properties, size)
+
+    return true
+  }
+
+  /** How many replies are being waited for. */
+  get pending () {
+    return this.#handlers.size
+  }
+}
 
 /**
  * @param {string} label
  * @returns {comq.ReplyEmitter}
  */
 function createReplyEmitter (label) {
-  const id = randomBytes(8).toString('hex')
-  const queue = concat(label, id)
-  const emitter = new EventEmitter()
-
-  emitter.setMaxListeners(0)
-  emitter.queue = queue
-
-  return /** @type {comq.ReplyEmitter} */ emitter
+  return new ReplyEmitter(label)
 }
 
 exports.createReplyEmitter = createReplyEmitter

--- a/source/attributes/lazy.js
+++ b/source/attributes/lazy.js
@@ -1,8 +1,18 @@
 'use strict'
 
+/**
+ * Runs the initializers once per distinct set of arguments before the method.
+ *
+ * The record of what has been initialized is kept per context, so that a context
+ * that is dropped takes its record with it, and it is looked up by argument rather
+ * than scanned — a channel publishing to a thousand queues asks for the thousandth
+ * as fast as for the first.
+ *
+ * @param {object} context
+ * @param {Function | Function[]} initializers
+ * @param {(...args: unknown[]) => Promise<unknown>} method
+ */
 function lazy (context, initializers, method) {
-  if (context[LOCK] === undefined) context[LOCK] = Symbol('methods locking key')
-
   if (!Array.isArray(initializers)) initializers = [initializers]
 
   return async function (...args) {
@@ -24,7 +34,7 @@ async function call (context, initializers, args) {
   let override
 
   for (const init of initializers) {
-    const result = await resolve(context, init, args)
+    const result = await lock(context, init, args)
 
     if (result !== undefined) override = result
   }
@@ -33,46 +43,76 @@ async function call (context, initializers, args) {
 }
 
 /**
- * @param {object} context
- * @param {Function} init
- * @param {any[]} args
- * @returns {Promise}
- */
-function resolve (context, init, args) {
-  const key = context[LOCK]
-  const expected = args.slice(0, init.length)
-
-  return lock(context, init, expected, key)
-}
-
-/**
+ * An initializer expecting N arguments is run once per distinct N leading
+ * arguments, which are the keys of a trie of Maps N levels deep.
+ *
  * @param {object} context
  * @param {(...args: unknown[]) => Promise<unknown>} init
  * @param {unknown[]} args
- * @param {Symbol} key
  * @returns {Promise<unknown>}
  */
-function lock (context, init, args, key) {
-  if (init[key] === undefined) init[key] = []
+function lock (context, init, args) {
+  const arity = init.length
 
-  const locks = init[key]
-  const found = locks.find((lock) => lock.args.reduce((match, argument, i) => match && argument === args[i], true))
+  let node = table(context, init)
 
-  if (found !== undefined) return found.promise
+  for (let i = 0; i < arity - 1; i++) node = branch(node, args[i])
 
-  const promise = init.apply(context, args)
-  const lock = { args, promise }
+  const key = arity === 0 ? NONE : args[arity - 1]
+  const found = node.get(key)
 
-  locks.push(lock)
+  if (found !== undefined) return found
+
+  const promise = init.apply(context, args.slice(0, arity))
+
+  node.set(key, promise)
 
   return promise
 }
 
-function reset (context) {
-  context[LOCK] = context[LOCK] = Symbol('methods locking key')
+/**
+ * @param {object} context
+ * @param {Function} init
+ * @return {Map<unknown, unknown>}
+ */
+function table (context, init) {
+  let tables = TABLES.get(context)
+
+  if (tables === undefined) {
+    tables = new Map()
+    TABLES.set(context, tables)
+  }
+
+  return branch(tables, init)
 }
 
-const LOCK = Symbol('context locking key')
+/**
+ * @param {Map<unknown, unknown>} node
+ * @param {unknown} key
+ * @return {Map<unknown, unknown>}
+ */
+function branch (node, key) {
+  let next = node.get(key)
+
+  if (next === undefined) {
+    next = new Map()
+    node.set(key, next)
+  }
+
+  return /** @type {Map<unknown, unknown>} */ next
+}
+
+/**
+ * @param {object} context
+ */
+function reset (context) {
+  TABLES.delete(context)
+}
+
+/** @type {WeakMap<object, Map<Function, Map<unknown, unknown>>>} */
+const TABLES = new WeakMap()
+
+const NONE = Symbol('no arguments')
 
 lazy.reset = reset
 

--- a/source/attributes/lazy.test.js
+++ b/source/attributes/lazy.test.js
@@ -297,3 +297,42 @@ describe('reset', () => {
     expect(initialize2).toHaveBeenCalledTimes(2)
   })
 })
+
+class Exposed {
+  do = lazy(this, this.initialize, async () => undefined)
+
+  async initialize (_) {}
+}
+
+// an initializer is a method shared by every instance of its class, so a record
+// kept on it would outlive the instances it was made for
+it('should keep no record on the initializer or the context', async () => {
+  const instance = new Exposed()
+
+  await instance.do(generate())
+  lazy.reset(instance)
+  await instance.do(generate())
+
+  expect(Object.getOwnPropertySymbols(Exposed.prototype.initialize)).toHaveLength(0)
+  expect(Object.getOwnPropertySymbols(instance)).toHaveLength(0)
+})
+
+it('should tell arguments apart by identity', async () => {
+  let calls = 0
+
+  class Counted {
+    do = lazy(this, this.initialize, async () => undefined)
+
+    async initialize (_) {
+      calls++
+    }
+  }
+
+  const instance = new Counted()
+
+  await instance.do(undefined)
+  await instance.do('undefined')
+  await instance.do(undefined)
+
+  expect(calls).toStrictEqual(2)
+})

--- a/source/attributes/recall.js
+++ b/source/attributes/recall.js
@@ -36,7 +36,24 @@ async function replay (context) {
   await Promise.all(promises)
 }
 
+/**
+ * Forgets the recorded calls, and the arguments they hold on to.
+ *
+ * @param {object} context
+ */
+function reset (context) {
+  const methods = context[METHODS]
+
+  if (methods === undefined) return
+
+  for (const method of methods) method[CALLS] = undefined
+
+  context[METHODS] = undefined
+}
+
 const METHODS = Symbol('context methods')
 const CALLS = Symbol('method calls')
+
+recall.reset = reset
 
 exports.recall = recall

--- a/source/attributes/recall.test.js
+++ b/source/attributes/recall.test.js
@@ -90,3 +90,46 @@ it('should not re-call those thrown exceptions', async () => {
 
   expect(method).toHaveBeenCalledTimes(3)
 })
+
+describe('reset', () => {
+  it('should be', async () => {
+    expect(recall.reset).toBeDefined()
+  })
+
+  it('should forget recorded calls', async () => {
+    const context = {}
+    const func = recall(context, method)
+
+    await func(generate())
+
+    recall.reset(context)
+    method.mockClear()
+
+    await recall(context)
+
+    expect(method).not.toHaveBeenCalled()
+  })
+
+  it('should record again after reset', async () => {
+    const context = {}
+    const func = recall(context, method)
+
+    await func(generate())
+
+    recall.reset(context)
+
+    const args = [generate()]
+
+    await func(...args)
+    method.mockClear()
+
+    await recall(context)
+
+    expect(method).toHaveBeenCalledTimes(1)
+    expect(method).toHaveBeenCalledWith(...args)
+  })
+
+  it('should not throw on a context without records', async () => {
+    expect(() => recall.reset({})).not.toThrow()
+  })
+})

--- a/source/channel.js
+++ b/source/channel.js
@@ -44,17 +44,22 @@ class Channel {
 
   #closed = false
 
+  /** @type {(channel: comq.Channel) => void} */
+  #release
+
   /**
    * @param {comq.amqp.Connection} connection
    * @param {comq.Topology} topology
-   * @param {number} index
+   * @param {number} [index]
+   * @param {(channel: comq.Channel) => void} [release] called once the channel is given back
    */
-  constructor (connection, topology, index) {
+  constructor (connection, topology, index, release = noop) {
     this.index = index
 
     this.#connection = connection
     this.#topology = topology
     this.#failfast = index !== undefined
+    this.#release = release
 
     if (this.#failfast) failsafe.disable(this.send, this.publish)
   }
@@ -62,6 +67,9 @@ class Channel {
   async create () {
     if (this.#topology.confirms) this.#channel = await this.#connection.createConfirmChannel()
     else this.#channel = await this.#connection.createChannel()
+
+    // the consumers of the previous channel went down with it, their tags mean nothing here
+    this.#tags = []
 
     await this.#channel.prefetch(this.#topology.prefetch)
 
@@ -141,6 +149,8 @@ class Channel {
 
     // a channel that went down with its connection is the outcome this asks for
     await this.#channel?.close().catch(noop)
+
+    this.#release(this)
   }
 
   async seal () {
@@ -149,6 +159,10 @@ class Channel {
     const cancellations = this.#tags.map((tag) => this.#channel.cancel(tag))
 
     await Promise.all(cancellations).catch(noop) // won't recover anyway
+
+    // a sealed channel is not going to consume again, so what it has consumed
+    // and the callbacks it was given are of no use anymore
+    recall.reset(this)
   }
 
   diagnose (event, listener) {
@@ -260,12 +274,12 @@ class Channel {
    */
   #confirmation () {
     const confirmation = new Promex()
+    const settled = () => this.#confirmations.delete(confirmation)
 
     this.#confirmations.add(confirmation)
 
-    confirmation
-      .catch(noop) // have no idea why, but this is required
-      .finally(() => this.#confirmations.delete(confirmation))
+    // one derived promise per publish, and a rejection handled with it
+    confirmation.then(settled, settled)
 
     return confirmation
   }
@@ -372,10 +386,11 @@ class Channel {
  * @param {comq.amqp.Connection} connection
  * @param {comq.Topology} topology
  * @param {number} [index]
+ * @param {(channel: comq.Channel) => void} [release]
  * @return {Promise<comq.Channel>}
  */
-async function create (connection, topology, index) {
-  const channel = new Channel(connection, topology, index)
+async function create (connection, topology, index, release) {
+  const channel = new Channel(connection, topology, index, release)
 
   await channel.create()
 

--- a/source/connection.js
+++ b/source/connection.js
@@ -20,8 +20,8 @@ class Connection {
   /** @type {comq.amqp.Connection} */
   #connection
 
-  /** @type {comq.Channel[]} */
-  #channels = []
+  /** @type {Set<comq.Channel>} */
+  #channels = new Set()
 
   /** @type {Promex} */
   #recovery = new Promex()
@@ -90,16 +90,23 @@ class Connection {
       if (this.#connection === undefined) await this.#recovery
 
       const topology = presets[type]
-      const channel = await channels.create(this.#connection, topology, index)
 
-      this.#channels = this.#channels.filter((channel) => !channel.closed)
-      this.#channels.push(channel)
+      // a closed channel held here would hold its IO, and a shared connection is
+      // in no hurry to make another channel that would have swept it out
+      const release = (channel) => this.#channels.delete(channel)
+      const channel = await channels.create(this.#connection, topology, index, release)
+
+      this.#channels.add(channel)
 
       return channel
     })
 
   async diagnose (event, listener) {
     this.#diagnostics.on(event, listener)
+  }
+
+  forget (event, listener) {
+    this.#diagnostics.off(event, listener)
   }
 
   #open = async (retry) => {
@@ -134,9 +141,10 @@ class Connection {
     this.#diagnostics.emit('open')
 
     try {
-      this.#channels = this.#channels.filter((channel) => !channel.closed)
-
-      for (const channel of this.#channels) await channel.recover(connection)
+      for (const channel of this.#channels) {
+        if (channel.closed) this.#channels.delete(channel)
+        else await channel.recover(connection)
+      }
     } catch (exception) {
       this.#diagnostics.emit('error', exception)
       this.#drop(connection)

--- a/source/io.js
+++ b/source/io.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const stream = require('node:stream')
-const { randomBytes } = require('node:crypto')
 const { setTimeout } = require('node:timers/promises')
 const { Promex } = require('promex')
 const { memo, failsafe, lazy, track } = require('./attributes')
@@ -38,6 +37,9 @@ class IO {
   /** @type {Map<Promex, comq.Request>} */
   #pendingReplies = new Map()
 
+  /** @type {[comq.diagnostics.Event, Function][]} */
+  #forwarders = []
+
   /** @type {Set<comq.Destroyable>} */
   #replyStreams = new Set()
 
@@ -53,7 +55,10 @@ class IO {
     this.#connection = connection
 
     for (const event of events.connection) {
-      this.#connection.diagnose(event, (...args) => this.#diagnostics.emit(event, ...args))
+      const forwarder = (...args) => this.#diagnostics.emit(event, ...args)
+
+      this.#connection.diagnose(event, forwarder)
+      this.#forwarders.push([event, forwarder])
     }
   }
 
@@ -87,10 +92,11 @@ class IO {
           )
         }
 
-        const request = this.#createRequest(queue, payload, encoding)
+        const [buffer, contentType] = this.#encode(payload, encoding)
+        const request = this.#createRequest(queue, contentType)
         const reply = this.#createReply(request)
 
-        await this.#requests.send(queue, request.buffer, request.properties)
+        await this.#requests.send(queue, buffer, request.properties)
 
         return reply
       }))
@@ -168,6 +174,11 @@ class IO {
     // here — held to the end of the connection, they would run it out of them
     await Promise.all([this.#requests, this.#replies, this.#events]
       .map((channel) => channel?.close()))
+
+    // a connection that outlives its IO must not keep it as a listener
+    for (const [event, forwarder] of this.#forwarders) this.#connection.forget(event, forwarder)
+
+    this.#forwarders = []
 
     await this.#connection.close()
   })
@@ -274,7 +285,7 @@ class IO {
     (message) => {
       const payload = decode(message)
 
-      emitter.emit(message.properties.correlationId, payload, message.properties)
+      emitter.emit(message.properties.correlationId, payload, message.properties, message.content.length)
     }
 
   /**
@@ -289,20 +300,21 @@ class IO {
     })
 
   /**
+   * The request holds no copy of what was sent: a retransmission encodes the
+   * payload anew, and an unanswered request would otherwise keep two of it.
+   *
    * @param {string} queue
-   * @param {any} payload
-   * @param {comq.Encoding} [encoding]
+   * @param {comq.Encoding} contentType
    * @return {comq.Request}
    */
-  #createRequest (queue, payload, encoding) {
-    const [buffer, contentType] = this.#encode(payload, encoding)
+  #createRequest (queue, contentType) {
     const emitter = this.#emitters.get(queue)
-    const correlationId = randomBytes(8).toString('hex')
+    const correlationId = emitter.next()
 
     /** @type {comq.amqp.Properties} */
     const properties = { contentType, correlationId, replyTo: emitter.queue }
 
-    return { buffer, emitter, properties }
+    return { emitter, properties }
   }
 
   /**
@@ -312,7 +324,7 @@ class IO {
   #createReply (request) {
     const reply = this.#createPendingReply(request)
 
-    request.emitter.once(request.properties.correlationId, this.#getReplyResolver(request, reply))
+    request.emitter.on(request.properties.correlationId, this.#getReplyResolver(request, reply))
 
     return reply
   }
@@ -323,12 +335,12 @@ class IO {
    */
   #createPendingReply (request) {
     const reply = new Promex()
+    const settled = () => this.#pendingReplies.delete(reply)
 
     this.#pendingReplies.set(reply, request)
 
-    reply
-      .catch(noop)
-      .finally(() => this.#pendingReplies.delete(reply))
+    // one derived promise per request, and a rejection handled with it
+    reply.then(settled, settled)
 
     return reply
   }
@@ -338,11 +350,14 @@ class IO {
    * @param reply
    */
   #getReplyResolver (request, reply) {
-    return async (payload, properties) => {
+    return async (payload, properties, size) => {
       const isStream = properties.headers?.index !== undefined
 
+      // a reply is answered once; a reply stream takes the place of this resolver
+      request.emitter.off(request.properties.correlationId)
+
       if (isStream) {
-        const stream = this.#createReplyStream(request, payload, properties)
+        const stream = this.#createReplyStream(request, payload, properties, size)
 
         try {
           await stream.confirmation
@@ -358,10 +373,10 @@ class IO {
     }
   }
 
-  #createReplyStream (request, payload, properties) {
+  #createReplyStream (request, payload, properties, size) {
     const stream = new io.ReplyStream(request, this.#reply.bind(this))
 
-    stream.arrange(payload, properties)
+    stream.arrange(payload, properties, size)
     this.#addReplyStream(/** @type {comq.Destroyable} */ stream)
 
     return stream
@@ -453,7 +468,7 @@ class IO {
     for (const [reply, request] of this.#pendingReplies) {
       // detaching this attempt alone leaves the listeners of the reply streams
       // that are still flowing over the other shards in place
-      request.emitter.removeAllListeners(request.properties.correlationId)
+      request.emitter.off(request.properties.correlationId)
 
       // trigger failsafe attribute
       reply.reject(RETRANSMISSION)
@@ -483,7 +498,5 @@ const OCTETS = 'application/octet-stream'
 const DEFAULT = 'application/json'
 
 const RETRANSMISSION = /** @type {Error} */ Symbol('retransmission')
-
-function noop () {}
 
 exports.IO = IO

--- a/source/pipeline.js
+++ b/source/pipeline.js
@@ -5,12 +5,20 @@ const stream = require('node:stream/promises')
 
 function pipeline (source, transform, channel) {
   const destination = new Pipeline(transform)
+  const pause = source.pause.bind(source)
+  const resume = source.resume.bind(source)
 
-  // eslint-disable-next-line no-void
-  void stream.pipeline(source, destination)
+  channel.diagnose('pause', pause)
+  channel.diagnose('resume', resume)
 
-  channel.diagnose('pause', source.pause.bind(source))
-  channel.diagnose('resume', source.resume.bind(source))
+  // the source must not outlive the pipeline as a listener of the channel;
+  // a failure is delivered through the destination, the promise says nothing new
+  const detach = () => {
+    channel.forget('pause', pause)
+    channel.forget('resume', resume)
+  }
+
+  stream.pipeline(source, destination).then(detach, detach)
 
   return destination
 }

--- a/source/shards/connection.js
+++ b/source/shards/connection.js
@@ -46,6 +46,10 @@ class Connection {
     this.#diagnostics.on(event, listener)
   }
 
+  forget (event, listener) {
+    this.#diagnostics.off(event, listener)
+  }
+
   /**
    * @param {comq.Connection} connection
    * @param {number} index

--- a/test/ReplyPipe.test.js
+++ b/test/ReplyPipe.test.js
@@ -1,0 +1,170 @@
+'use strict'
+
+const { Readable } = require('node:stream')
+const { Promex } = require('promex')
+const { ReplyPipe } = require('../source/.io/ReplyPipe')
+const { createReplyEmitter } = require('../source/.io/createReplyEmitter')
+const { control, FLOW_HEADER } = require('../source/.io/const')
+const { timeout } = require('./helpers')
+
+/** @type {jest.Mock} */
+let reply
+
+/** @type {[any, comq.amqp.options.Publish][]} */
+let sent
+
+let channel
+
+/** @type {comq.ReplyEmitter} */
+let feedback
+
+let request
+
+beforeEach(() => {
+  global.COMQ_TESTING_HEARTBEAT_INTERVAL = 60_000
+
+  sent = []
+  reply = jest.fn(async (message, properties) => {
+    sent.push([message, properties])
+
+    return true
+  })
+
+  channel = { diagnose: jest.fn(), forget: jest.fn() }
+  feedback = createReplyEmitter('control')
+  request = { properties: { correlationId: 'test-correlation', replyTo: 'replies' } }
+})
+
+afterEach(() => {
+  delete global.COMQ_TESTING_HEARTBEAT_INTERVAL
+})
+
+const messages = () => sent.map(([message]) => message)
+
+const closing = (pipe) => new Promise((resolve) => pipe.on('close', resolve))
+
+it('should confirm, announcing flow control', async () => {
+  const pipe = await ReplyPipe.create(request, Readable.from([]), channel, feedback, reply)
+
+  expect(sent[0][0]).toStrictEqual(control.ok)
+  expect(sent[0][1].headers).toStrictEqual({ index: 0, [FLOW_HEADER]: true })
+
+  await closing(pipe)
+})
+
+it('should transmit values in order, then end', async () => {
+  const pipe = await ReplyPipe.create(request, Readable.from([1, 2, 3]), channel, feedback, reply)
+
+  await closing(pipe)
+
+  expect(messages()).toStrictEqual([control.ok, 1, 2, 3, control.end])
+  expect(sent.map(([, properties]) => properties.headers.index)).toStrictEqual([0, 1, 2, 3, 4])
+})
+
+// a source listened to runs at its own pace, and its output piles up in front of a paused channel
+it('should pull the source no faster than the channel takes', async () => {
+  const gate = new Promex()
+
+  let pulled = 0
+
+  reply.mockImplementation(async (message) => {
+    if (message !== control.ok) await gate
+
+    return true
+  })
+
+  function * source () {
+    for (let i = 0; i < 100; i++) {
+      pulled++
+
+      yield i
+    }
+  }
+
+  const pipe = await ReplyPipe.create(request, Readable.from(source()), channel, feedback, reply)
+
+  await timeout(10)
+
+  // a Readable reads ahead by no more than its high water mark
+  expect(pulled).toBeLessThanOrEqual(20)
+
+  gate.resolve()
+
+  await closing(pipe)
+
+  expect(pulled).toStrictEqual(100)
+})
+
+it('should hold the source while the consumer has asked for a pause', async () => {
+  const pipe = await ReplyPipe.create(request, Readable.from([1, 2, 3]), channel, feedback, reply)
+
+  feedback.emit(request.properties.correlationId, control.pause, {})
+
+  await timeout(10)
+
+  expect(messages()).toStrictEqual([control.ok])
+
+  feedback.emit(request.properties.correlationId, control.resume, {})
+
+  await closing(pipe)
+
+  expect(messages()).toStrictEqual([control.ok, 1, 2, 3, control.end])
+})
+
+it('should stop once the consumer has ended the stream', async () => {
+  const gate = new Promex()
+
+  reply.mockImplementation(async (message, properties) => {
+    sent.push([message, properties])
+
+    if (message !== control.ok) await gate
+
+    return true
+  })
+
+  const pipe = await ReplyPipe.create(request, Readable.from([1, 2, 3]), channel, feedback, reply)
+  const closed = closing(pipe)
+
+  feedback.emit(request.properties.correlationId, control.end, {})
+
+  await closed
+
+  gate.resolve()
+
+  await timeout(10)
+
+  expect(messages()).not.toContain(control.end)
+  expect(messages()).not.toContain(3)
+  expect(channel.forget).toHaveBeenCalledWith('return', expect.any(Function))
+  expect(feedback.pending).toStrictEqual(0)
+})
+
+it('should not heartbeat once the confirmation could not be delivered', async () => {
+  global.COMQ_TESTING_HEARTBEAT_INTERVAL = 5
+
+  reply.mockImplementation(async (message, properties) => {
+    sent.push([message, properties])
+
+    return false
+  })
+
+  const pipe = new ReplyPipe(request, Readable.from([1]), channel, feedback, reply)
+
+  await pipe.pipe()
+  await timeout(30)
+
+  expect(messages()).toStrictEqual([control.ok])
+})
+
+it('should heartbeat while idle', async () => {
+  global.COMQ_TESTING_HEARTBEAT_INTERVAL = 5
+
+  const source = new Readable({ objectMode: true, read () {} })
+  const pipe = await ReplyPipe.create(request, source, channel, feedback, reply)
+
+  await timeout(30)
+
+  expect(messages()).toContain(control.heartbeat)
+
+  pipe.destroy()
+})

--- a/test/ReplyStream.test.js
+++ b/test/ReplyStream.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const { EventEmitter } = require('node:events')
 const { once } = require('node:events')
 const { ReplyStream, UNCONFIRMED } = require('../source/.io/ReplyStream')
-const { control } = require('../source/.io/const')
+const { createReplyEmitter } = require('../source/.io/createReplyEmitter')
+const { control, FLOW_HEADER } = require('../source/.io/const')
 
 /** @type {jest.Mock} */
 let reply
@@ -18,7 +18,7 @@ beforeEach(() => {
   reply = jest.fn().mockResolvedValue(true)
 
   const request = {
-    emitter: new EventEmitter(),
+    emitter: createReplyEmitter('test'),
     properties: { correlationId: 'test-correlation' }
   }
 
@@ -63,7 +63,7 @@ it('should reject confirmation when nothing arrives within the idle interval', a
   global.COMQ_TESTING_IDLE_INTERVAL = 10
 
   const request = {
-    emitter: new EventEmitter(),
+    emitter: createReplyEmitter('test'),
     properties: { correlationId: 'idle-correlation' }
   }
 
@@ -80,4 +80,82 @@ it('should keep confirmation resolved after control.ok', async () => {
   stream.destroy()
 
   await expect(stream.confirmation).resolves.toBeUndefined()
+})
+
+describe('flow', () => {
+  const TOTAL = 40 // well beyond the 16 values a Readable holds in object mode
+
+  /**
+   * @param {boolean} flow whether the producer honours pause and resume
+   */
+  const ok = (flow) => ({ headers: { index: 0, [FLOW_HEADER]: flow }, type: 'control' })
+
+  const send = () => {
+    for (let index = 1; index <= TOTAL; index++) stream.arrange(index, { headers: { index } })
+
+    stream.arrange(control.end, { headers: { index: TOTAL + 1 }, type: 'control' })
+  }
+
+  // dropping the listener once behind would leave the stream waiting for values that have passed
+  it('should keep receiving while the consumer is behind', async () => {
+    stream.arrange(control.ok, ok(false))
+    send()
+
+    const received = []
+
+    for await (const value of stream) received.push(value)
+
+    expect(received).toHaveLength(TOTAL)
+    expect(received[TOTAL - 1]).toStrictEqual(TOTAL)
+  })
+
+  it('should not ask a producer that knows nothing of pause', async () => {
+    stream.arrange(control.ok, ok(false))
+    send()
+
+    expect(reply).not.toHaveBeenCalled()
+  })
+
+  it('should ask the producer to pause once behind, and to resume once caught up', async () => {
+    stream.arrange(control.ok, ok(true))
+
+    for (let index = 1; index <= TOTAL; index++) stream.arrange(index, { headers: { index } })
+
+    expect(reply).toHaveBeenCalledTimes(1)
+    expect(reply).toHaveBeenCalledWith({ properties: ok(true) }, control.pause)
+
+    const drained = new Promise((resolve) => stream.on('data', (value) => { if (value === TOTAL) resolve() }))
+
+    await drained
+
+    expect(reply).toHaveBeenCalledTimes(2)
+    expect(reply).toHaveBeenLastCalledWith({ properties: ok(true) }, control.resume)
+  })
+
+  it('should bound the values held out of order by their size', async () => {
+    global.COMQ_TESTING_MAX_BUFFER_SIZE = 1000
+    global.COMQ_TESTING_MAX_BUFFER_BYTES = 100
+
+    try {
+      const request = {
+        emitter: createReplyEmitter('test'),
+        properties: { correlationId: 'bytes-correlation' }
+      }
+
+      const held = new ReplyStream(request, reply)
+      const closed = once(held, 'close')
+
+      held.arrange(1, { headers: { index: 1 } }, 60)
+
+      expect(held.destroyed).toBe(false)
+
+      held.arrange(2, { headers: { index: 2 } }, 60)
+
+      await closed
+
+      expect(held.destroyed).toBe(true)
+    } finally {
+      delete global.COMQ_TESTING_MAX_BUFFER_BYTES
+    }
+  })
 })

--- a/test/channel.test.js
+++ b/test/channel.test.js
@@ -971,3 +971,61 @@ const getCreatedChannel = (conn) => {
 
   return (conn ?? connection)[method].mock.results[0].value
 }
+
+describe('consumer tags', () => {
+  const queue = generate()
+  const consumer = jest.fn()
+
+  beforeEach(async () => {
+    channel = await create(connection, topology)
+    chan = await getCreatedChannel()
+  })
+
+  // the consumers of a lost channel went down with it, and their tags would pile
+  // up with every reconnection to be cancelled on a channel that never had them
+  it('should cancel the consumers of the current channel only', async () => {
+    await channel.consume(queue, consumer)
+
+    const replacement = await amqplib.connect()
+
+    await channel.recover(replacement)
+
+    const repl = await getCreatedChannel(replacement)
+
+    expect(repl.consume).toHaveBeenCalledTimes(1)
+
+    const { consumerTag } = await repl.consume.mock.results[0].value
+
+    await channel.seal()
+
+    expect(repl.cancel).toHaveBeenCalledTimes(1)
+    expect(repl.cancel).toHaveBeenCalledWith(consumerTag)
+  })
+
+  it('should let go of the recorded subscriptions once sealed', async () => {
+    await channel.consume(queue, consumer)
+    await channel.seal()
+
+    const replacement = await amqplib.connect()
+
+    await channel.recover(replacement)
+
+    const repl = await getCreatedChannel(replacement)
+
+    expect(repl.consume).not.toHaveBeenCalled()
+  })
+})
+
+describe('release', () => {
+  it('should be called once the channel is closed', async () => {
+    const release = jest.fn()
+
+    channel = await create(connection, topology, undefined, release)
+
+    expect(release).not.toHaveBeenCalled()
+
+    await channel.close()
+
+    expect(release).toHaveBeenCalledWith(channel)
+  })
+})

--- a/test/connection.mock.js
+++ b/test/connection.mock.js
@@ -11,6 +11,7 @@ const channel = /** @type {jest.MockedFunction<(sharded?: boolean, index?: numbe
     subscribe: jest.fn(async () => undefined),
     publish: jest.fn(async () => undefined),
     diagnose: jest.fn(async () => undefined),
+    forget: jest.fn(() => undefined),
     seal: jest.fn(async () => undefined),
     close: jest.fn(async () => undefined),
     closed: false,
@@ -26,7 +27,8 @@ const connection = (sharded = false) => (/** @type {jest.MockedObject<comq.Conne
   createChannel: jest.fn(async (type, index) => channel(sharded, index)),
   open: jest.fn(async () => undefined),
   close: jest.fn(async () => undefined),
-  diagnose: jest.fn(() => undefined)
+  diagnose: jest.fn(() => undefined),
+  forget: jest.fn(() => undefined)
 })
 
 exports.connection = connection

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -356,7 +356,7 @@ describe('create channel', () => {
       const preset = presets[type]
       const channel = await connection.createChannel(type)
 
-      expect(create).toHaveBeenCalledWith(conn, preset, undefined)
+      expect(create).toHaveBeenCalledWith(conn, preset, undefined, expect.any(Function))
       expect(channel).toStrictEqual(await create.mock.results[0].value)
     })
 
@@ -366,7 +366,7 @@ describe('create channel', () => {
 
     await connection.createChannel(type, index)
 
-    expect(create).toHaveBeenCalledWith(expect.anything(), expect.anything(), index)
+    expect(create).toHaveBeenCalledWith(expect.anything(), expect.anything(), index, expect.any(Function))
   })
 
   it('should create channel after exception', async () => {
@@ -466,6 +466,21 @@ describe('closed channels', () => {
     await timeout(50)
 
     expect(channel.recover).toHaveBeenCalled()
+  })
+
+  // a closed channel held by a shared connection would hold its IO until the
+  // connection happens to make another channel
+  it('should let go of one that has been given back', async () => {
+    const channel = await connection.createChannel('event')
+    const release = create.mock.calls[0][3]
+
+    release(channel)
+
+    conn.emit('close', new Error())
+
+    await timeout(50)
+
+    expect(channel.recover).not.toHaveBeenCalled()
   })
 })
 
@@ -793,5 +808,22 @@ describe('diagnostics', () => {
     for (let i = 0; i < 100; i++) {
       connection.diagnose('close', () => undefined)
     }
+  })
+})
+
+describe('forget', () => {
+  afterEach(async () => {
+    await connection.close()
+  })
+
+  it('should stop reporting to the listener', async () => {
+    const listener = /** @type {Function} */ jest.fn()
+
+    await connection.diagnose('open', listener)
+    connection.forget('open', listener)
+
+    await connection.open()
+
+    expect(listener).not.toHaveBeenCalled()
   })
 })

--- a/test/io.diagnostics.test.js
+++ b/test/io.diagnostics.test.js
@@ -93,3 +93,14 @@ const findChannel = (type) => {
 
   return connection.createChannel.mock.results[index].value
 }
+
+// a connection is shared and outlives its IOs, so a listener left on it would hold the IO
+it('should forget the connection listeners on close', async () => {
+  await io.close()
+
+  for (const [event, listener] of connection.diagnose.mock.calls) {
+    expect(connection.forget).toHaveBeenCalledWith(event, listener)
+  }
+
+  expect(connection.forget).toHaveBeenCalledTimes(connection.diagnose.mock.calls.length)
+})

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -1,0 +1,273 @@
+'use strict'
+
+// Watches what a closed IO leaves behind. Every scenario keeps weak references to
+// what it has opened and closed, and expects the garbage collector to have taken
+// all of it; the heap growth per iteration is reported alongside.
+
+const v8 = require('node:v8')
+const vm = require('node:vm')
+const stream = require('node:stream')
+const { generate } = require('randomstring')
+const { timeout } = require('./helpers')
+const mock = require('./amqplib.mock')
+const { amqplib, connect } = mock
+
+jest.mock('amqplib', () => mock.amqplib)
+
+const { connect: open, assert } = require('../source')
+const { SingletonConnection } = require('../source/singleton')
+
+v8.setFlagsFromString('--expose-gc')
+
+const gc = vm.runInNewContext('gc')
+
+/** @type {{ scenario: string, iterations: number, watched: number, retained: number, growth: string }[]} */
+const report = []
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  amqplib.connect.mockImplementation(async (url) => wired(await connect(url)))
+
+  global.COMQ_TESTING_SHUTDOWN_TIMEOUT = 1
+  global.COMQ_TESTING_WATCHDOG_INTERVAL = 60_000
+})
+
+afterEach(() => {
+  SingletonConnection.__lets_pretend_this_method_doesnt_exist()
+
+  delete global.COMQ_TESTING_SHUTDOWN_TIMEOUT
+  delete global.COMQ_TESTING_WATCHDOG_INTERVAL
+})
+
+afterAll(() => {
+  console.info('Memory report (heap growth is per iteration, after garbage collection)\n' +
+    formatted(report))
+})
+
+it('should let go of an IO and its channels once closed', async () => {
+  const retained = await measure('connect, reply, consume, emit, close', 100, async () => {
+    const io = await open(generate())
+
+    await io.reply(generate(), () => generate())
+    await io.consume(generate(), generate(), () => undefined)
+    await io.emit(generate(), { value: generate() })
+    await io.enqueue(generate(), { value: generate() })
+
+    const channels = await amqpChannels()
+
+    await io.close()
+
+    return [io, ...channels]
+  })
+
+  expect(retained).toStrictEqual(0)
+})
+
+// a singleton connection outlives every IO opened on it
+it('should let go of the IOs of a singleton connection', async () => {
+  const url = generate()
+
+  const retained = await measure('assert, reply, close (singleton)', 100, async () => {
+    const io = await assert(url)
+
+    await io.reply(generate(), () => generate())
+
+    const channels = await amqpChannels()
+
+    await io.close()
+
+    return [io, ...channels]
+  })
+
+  expect(retained).toStrictEqual(0)
+})
+
+it('should let go of the streams passed to request and emit', async () => {
+  const io = await open(generate())
+  const queue = generate()
+  const exchange = generate()
+
+  await io.reply(queue, (request) => request)
+
+  const retained = await measure('request and emit with a stream', 100, async () => {
+    const requests = stream.Readable.from([{ a: generate() }, { b: generate() }])
+    const events = stream.Readable.from([{ a: generate() }, { b: generate() }])
+
+    const replies = await io.request(queue, requests)
+
+    // eslint-disable-next-line no-void, no-unused-vars
+    for await (const _ of replies) void 0
+
+    await io.emit(exchange, events)
+
+    return [requests, events]
+  })
+
+  await io.close()
+
+  expect(retained).toStrictEqual(0)
+})
+
+it('should let go of the channels lost with a connection', async () => {
+  const io = await open(generate())
+
+  await io.reply(generate(), () => generate())
+  await io.consume(generate(), generate(), () => undefined)
+
+  const retained = await measure('reconnection', 50, async () => {
+    const before = await amqpChannels()
+    const conn = await amqplib.connect.mock.results.at(-1).value
+
+    let recovered = 0
+
+    const recovery = new Promise((resolve) => io.diagnose('recover', () => { if (++recovered === 3) resolve() }))
+
+    conn.emit('close', new Error(generate()))
+
+    await recovery
+
+    return before
+  })
+
+  await io.close()
+
+  expect(retained).toStrictEqual(0)
+})
+
+/**
+ * @param {string} scenario
+ * @param {number} iterations
+ * @param {(index: number) => Promise<object[]>} iteration returning what must be collected afterwards
+ * @return {Promise<number>} how many of the watched objects are still alive
+ */
+async function measure (scenario, iterations, iteration) {
+  /** @type {WeakRef<object>[]} */
+  const refs = []
+
+  await collect()
+
+  const before = process.memoryUsage().heapUsed
+
+  // in a frame of its own, so that nothing of the last iteration is left on the stack
+  await watch(refs, iterations, iteration)
+
+  // mocks remember what they returned, and spies are registered until restored,
+  // either of which would keep what they were made on alive
+  jest.clearAllMocks()
+  jest.restoreAllMocks()
+
+  await collect()
+
+  const after = process.memoryUsage().heapUsed
+  const retained = refs.filter((ref) => ref.deref() !== undefined).length
+  const growth = ((after - before) / iterations / 1024).toFixed(1) + ' KB'
+
+  report.push({ scenario, iterations, watched: refs.length, retained, growth })
+
+  return retained
+}
+
+/**
+ * @param {WeakRef<object>[]} refs
+ * @param {number} iterations
+ * @param {(index: number) => Promise<object[]>} iteration
+ */
+async function watch (refs, iterations, iteration) {
+  for (let i = 0; i < iterations; i++) {
+    const objects = await iteration(i)
+
+    for (const object of objects) refs.push(new WeakRef(object))
+  }
+}
+
+/**
+ * The channels amqplib has been asked for since the last call.
+ *
+ * @return {Promise<object[]>}
+ */
+async function amqpChannels () {
+  const channels = []
+
+  for (const { value } of amqplib.connect.mock.results) {
+    const conn = await value
+
+    for (const method of ['createChannel', 'createConfirmChannel']) {
+      for (const result of conn[method].mock.results) channels.push(await result.value)
+
+      conn[method].mockClear()
+    }
+  }
+
+  return channels
+}
+
+/**
+ * A broker of sorts: what is published to a queue is delivered to its consumer,
+ * so that requests are answered and streams of them come to an end.
+ *
+ * @param {jest.MockedObject<comq.amqp.Connection>} conn
+ * @return {jest.MockedObject<comq.amqp.Connection>}
+ */
+function wired (conn) {
+  const consumers = new Map()
+  const tags = new Map()
+
+  // a broker forgets the consumers of a connection that is gone
+  conn.on('close', () => consumers.clear())
+
+  for (const method of ['createChannel', 'createConfirmChannel']) {
+    const create = conn[method].getMockImplementation()
+
+    conn[method].mockImplementation(async () => {
+      const chan = await create()
+
+      chan.consume.mockImplementation(async (queue, callback) => {
+        const consumerTag = generate()
+
+        consumers.set(queue, callback)
+        tags.set(consumerTag, queue)
+
+        return { consumerTag }
+      })
+
+      chan.cancel.mockImplementation(async (consumerTag) => {
+        consumers.delete(tags.get(consumerTag))
+        tags.delete(consumerTag)
+      })
+
+      chan.publish.mockImplementation((exchange, routingKey, content, properties, resolve) => {
+        resolve?.(null)
+
+        const callback = consumers.get(routingKey)
+
+        if (callback !== undefined) setImmediate(callback, { content, properties, fields: { exchange, routingKey } })
+
+        return true
+      })
+
+      return chan
+    })
+  }
+
+  return conn
+}
+
+async function collect () {
+  // an object a WeakRef was made for in the current task is kept until the task ends
+  await timeout(0)
+
+  gc()
+  gc()
+
+  await timeout(0)
+
+  gc()
+}
+
+function formatted (rows) {
+  const columns = ['scenario', 'iterations', 'watched', 'retained', 'growth']
+  const width = (column) => Math.max(column.length, ...rows.map((row) => String(row[column]).length))
+  const line = (cells) => cells.map((cell, i) => String(cell).padEnd(width(columns[i]))).join('  ')
+
+  return [line(columns), ...rows.map((row) => line(columns.map((column) => row[column])))].join('\n')
+}

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -78,4 +78,25 @@ class Channel extends EventEmitter {
   diagnose (event, callback) {
     this.on(event, callback)
   }
+
+  forget (event, callback) {
+    this.off(event, callback)
+  }
 }
+
+// the source must not stay a listener of the channel once the pipeline is done
+it('should let go of the source once done', async () => {
+  const input = stream.Readable.from([1, 2, 3])
+  const pipe = pipeline(input, (x) => x, channel)
+
+  expect(channel.listenerCount('pause')).toBe(1)
+  expect(channel.listenerCount('resume')).toBe(1)
+
+  // eslint-disable-next-line no-void, no-unused-vars
+  for await (const _ of pipe) void 0
+
+  await timeout(0)
+
+  expect(channel.listenerCount('pause')).toBe(0)
+  expect(channel.listenerCount('resume')).toBe(0)
+})

--- a/test/shards/connection.test.js
+++ b/test/shards/connection.test.js
@@ -132,3 +132,18 @@ describe.each(/** @type {comq.diagnostics.Event[]} */ ['open', 'close'])('diagno
       expect(listener).toHaveBeenCalledWith(event, ...args, index)
     })
   })
+
+describe('forget', () => {
+  it('should stop re-emitting to the listener', async () => {
+    const listener = /** @type {Function} */ jest.fn()
+
+    connection.diagnose('open', listener)
+    connection.forget('open', listener)
+
+    const call = connections[0].diagnose.mock.calls.find((call) => call[0] === 'open')
+
+    call[1]()
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/types/connection.d.ts
+++ b/types/connection.d.ts
@@ -18,6 +18,8 @@ declare namespace comq {
     createChannel(type: _topology.type, index: number): Promise<_channel.Channel>
 
     diagnose(event: _diagnostics.Event, listener: Function): void
+
+    forget(event: _diagnostics.Event, listener: Function): void
   }
 
   type Connect = (...urls: string[]) => Promise<_io.IO>

--- a/types/io.d.ts
+++ b/types/io.d.ts
@@ -10,8 +10,21 @@ declare namespace comq {
   type Producer<Input = any, Output = any> = (message: Input) => Output | Promise<Output>
   type Consumer<T = any> = (message: T, headers?: _amqp.Properties) => void | Promise<void>
 
-  interface ReplyEmitter extends EventEmitter {
+  type ReplyHandler = (payload: any, properties: _amqp.Properties, size?: number) => void
+
+  interface ReplyEmitter {
     readonly queue: string
+
+    /** A correlation identifier unique across every consumer of a producer. */
+    next(): string
+
+    on(correlationId: string, handler: ReplyHandler): void
+
+    off(correlationId: string, handler?: ReplyHandler): void
+
+    emit(correlationId: string, payload: any, properties: _amqp.Properties, size?: number): boolean
+
+    readonly pending: number
   }
 
   interface Destroyable extends EventEmitter {
@@ -19,7 +32,6 @@ declare namespace comq {
   }
 
   interface Request {
-    buffer: Buffer
     emitter: ReplyEmitter
     properties: _amqp.Properties
   }


### PR DESCRIPTION
Promotes `dev` to `release`.

## Included

- fix: memory leaks, unbounded buffering and the cost of a request (#263)
- chore(deps-dev): bump jest from 30.4.2 to 30.5.0 (#260)
- chore(deps-dev): bump conventional-changelog-conventionalcommits from 8.0.0 to 10.4.0 (#259)

See #263 for the details: the leaks closed on shared connections, pipelines, `lazy` records and consumer tags; flow control for reply streams (`pause`/`resume` announced via the `x-flow` header, older producers unaffected); the request/reply hot path at 4.2 µs instead of 7.0 µs per round trip; and `test/memory.test.js` guarding the leaks.

## Verification

- `npm test`: 409 unit tests
- `npm run features`: 59 cucumber scenarios against RabbitMQ in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)