### PR TITLE
fix: release 0.16.2 with its notes rendered

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     target-branch: "dev"
     labels:
       - "Bump"
+    ignore:
+      # a newer preset needs conventional-changelog-writer@9, which the
+      # semantic-release plugins do not use yet; the release fails to render its notes
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types: ["version-update:semver-major"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@testcontainers/rabbitmq": "^12.1.0",
         "@types/amqplib": "^0.10.8",
         "@types/jest": "^30.0.0",
-        "conventional-changelog-conventionalcommits": "^10.4.0",
+        "conventional-changelog-conventionalcommits": "^8.0.0",
         "fast-glob": "^3.3.3",
         "fuzzysort": "4.0.2",
         "husky": "^9.1.7",
@@ -620,16 +620,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
-      "integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@cucumber/ci-environment": {
@@ -4990,16 +4980,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
+      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@testcontainers/rabbitmq": "^12.1.0",
     "@types/amqplib": "^0.10.8",
     "@types/jest": "^30.0.0",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^8.0.0",
     "fast-glob": "^3.3.3",
     "fuzzysort": "4.0.2",
     "husky": "^9.1.7",


### PR DESCRIPTION
Promotes `dev` to `release` again after the failed run of 0.16.2 ([34082180068](https://github.com/toa-io/comq/actions/runs/34082180068)).

Included: #265, which pins `conventional-changelog-conventionalcommits` back to 8 so that semantic-release can render the release notes.

Released with it: the memory leak fixes and reply stream flow control from #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)