### PR TITLE
fix: routed exchanges over a sharded connection

### DIFF
--- a/features/events.routed.feature
+++ b/features/events.routed.feature
@@ -17,3 +17,9 @@ Feature: Routed events
     When a message is routed to the `records` exchange under the `placed` key
     Then `orders` receives the event
     And `customers` receives nothing
+
+  Scenario: Routing over a sharded connection
+    Given an active sharded connection
+    And that `orders` is bound to the `records` exchange under the `placed` key
+    When a message is routed to the `records` exchange under the `placed` key
+    Then `orders` receives the event

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,9 @@ The queue is named rather than derived from a Consumer group, because what ident
 the Key it is bound under rather than the exchange it belongs to. It is also durable, so what is
 published while nothing is consuming is held rather than dropped.
 
+Over a [sharded connection](#sharded-connection) they behave as the rest does: `route` publishes
+to one shard, and `subscribe` consumes the queue on every one of them.
+
 ### Example
 
 ```javascript

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -64,12 +64,20 @@ class Channel {
     await this.#every((channel) => channel.subscribe(queue, group, consumer))
   }
 
+  async bound (exchange, queue, key, consumer) {
+    await this.#every((channel) => channel.bound(exchange, queue, key, consumer))
+  }
+
   async send (queue, buffer, options) {
     await this.#one((channel) => channel.send(queue, buffer, options))
   }
 
   async publish (exchange, buffer, options) {
     await this.#one((channel) => channel.publish(exchange, buffer, options))
+  }
+
+  async route (exchange, key, buffer, options) {
+    await this.#one((channel) => channel.route(exchange, key, buffer, options))
   }
 
   async fire (queue, buffer, options) {

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -718,3 +718,36 @@ async function getCreatedChannels () {
 
   return await Promise.all(promises)
 }
+
+describe('routed', () => {
+  const exchange = generate()
+  const queue = generate()
+  const key = generate()
+  const buffer = randomBytes(8)
+  const consumer = jest.fn()
+
+  /** @type {jest.MockedObject<comq.Channel>[]} */
+  let channels
+
+  beforeEach(async () => {
+    channel = await create(connections, type)
+    channels = await getCreatedChannels()
+  })
+
+  it('should bind using all channels', async () => {
+    await channel.bound(exchange, queue, key, consumer)
+
+    for (const chan of channels) {
+      expect(chan.bound).toHaveBeenCalledWith(exchange, queue, key, consumer)
+    }
+  })
+
+  it('should route to a single channel', async () => {
+    await channel.route(exchange, key, buffer)
+
+    const used = channels.filter((chan) => chan.route.mock.calls.length > 0)
+
+    expect(used).toHaveLength(1)
+    expect(used[0].route).toHaveBeenCalledWith(exchange, key, buffer, undefined)
+  })
+})


### PR DESCRIPTION
`route` and `bound` were added to `source/channel.js` and not to `source/shards/channel.js`, so a connection to more than one broker answers that they are not functions. #268 shipped with that hole.

## Reproduced first, on both levels

**Unit**, against the real `shards/channel.js` with mocked connections:

```
● routed › should bind using all channels
  TypeError: channel.bound is not a function
● routed › should route to a single channel
  TypeError: channel.route is not a function
```

**Feature**, over the two brokers the compose file already has:

```
Scenario: Routing over a sharded connection
  Given an active sharded connection
  And that `orders` is bound to the `records` exchange under the `placed` key
    TypeError: this[#events].bound is not a function
        at IO.<anonymous> (source/io.js:174:26)
```

No federation and no second region are needed to see it: `assert()` switches to the sharded channel on the second URL, and the first call fails there.

## The fix

They follow the same rule as the pair beside them — *send to one, receive from all*:

- `route` → `#one`, as `publish` does.
- `bound` → `#every`, as `subscribe` does.

## Verification

- `npm test` — 425 unit tests, `standard` clean. Two new in `test/shards/channel.test.js`.
- `npm run features:fast` — 36 scenarios, 229 steps. One new in `features/events.routed.feature`, which is the scenario that would have caught this: every other routed one runs over a single broker, which is the path that worked.
- The readme's Routing section says what the pair does over a sharded connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)