### PR TITLE
release: routed exchanges over a sharded connection

### DIFF
--- a/features/events.routed.feature
+++ b/features/events.routed.feature
@@ -17,3 +17,9 @@ Feature: Routed events
     When a message is routed to the `records` exchange under the `placed` key
     Then `orders` receives the event
     And `customers` receives nothing
+
+  Scenario: Routing over a sharded connection
+    Given an active sharded connection
+    And that `orders` is bound to the `records` exchange under the `placed` key
+    When a message is routed to the `records` exchange under the `placed` key
+    Then `orders` receives the event

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,17 +1252,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.5.0.tgz",
-      "integrity": "sha512-BI1DpOedrJqbrYVi9yNhDWGjqphR/+gsM4STmg2+VaeXm7851hvpBDyKOZGMXATTrGEnFuEseQvLCtrrRmG0GQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.5.1.tgz",
+      "integrity": "sha512-u5Ncuc+gXVUwjNMFQOnphHo2Qx2DxyC8Dvpmf4HCx4y0kvSkRRNiQYRixrvOP4V7y52JcSuNxqochCt0PpdHVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.5.0",
-        "jest-util": "30.5.0",
+        "jest-message-util": "30.5.1",
+        "jest-util": "30.5.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1270,18 +1270,18 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.5.0.tgz",
-      "integrity": "sha512-DLjRME+NY//j+UDTSfWnjoP0srrdR3DrJRy7yFZktGIwzpN2iVy2vMo0jziZ5c2Ij7bOwlJRXKVWtxZusazOJg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.5.1.tgz",
+      "integrity": "sha512-BL9g6CJUUhIbdoAflz/Va658erSSXUIvU8XUYiWNTbZljJjZ5yaC9EJ9/dQ19rpbYV3ZOK4sBACqhPaTyhoUIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.5.0",
+        "@jest/console": "30.5.1",
         "@jest/pattern": "30.5.0",
-        "@jest/reporters": "30.5.0",
-        "@jest/test-result": "30.5.0",
-        "@jest/transform": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/reporters": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
@@ -1289,20 +1289,20 @@
         "exit-x": "^0.2.2",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.5.0",
-        "jest-config": "30.5.0",
-        "jest-haste-map": "30.5.0",
-        "jest-message-util": "30.5.0",
+        "jest-changed-files": "30.5.1",
+        "jest-config": "30.5.1",
+        "jest-haste-map": "30.5.1",
+        "jest-message-util": "30.5.1",
         "jest-regex-util": "30.5.0",
-        "jest-resolve": "30.5.0",
-        "jest-resolve-dependencies": "30.5.0",
-        "jest-runner": "30.5.0",
-        "jest-runtime": "30.5.0",
-        "jest-snapshot": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-validate": "30.5.0",
-        "jest-watcher": "30.5.0",
-        "pretty-format": "30.5.0",
+        "jest-resolve": "30.5.1",
+        "jest-resolve-dependencies": "30.5.1",
+        "jest-runner": "30.5.1",
+        "jest-runtime": "30.5.1",
+        "jest-snapshot": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
+        "jest-watcher": "30.5.1",
+        "pretty-format": "30.5.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1328,39 +1328,39 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.5.0.tgz",
-      "integrity": "sha512-HUaqexIauIh69IQ4NTuPDEUCB8g8T4TOPSIzQOS18mwI/KEHKQk1j013K2o6ra031szZE2t5jGmVx3xbzdjgKA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.5.1.tgz",
+      "integrity": "sha512-eYJAkOsrpwDXPcoLNEG6lN9Zo3Cy35pxnVQD74vyIfsi/Q8wB/lZFsEjU4wrecOgT4ZviQDZaX/cFIJyMdMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/fake-timers": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
-        "jest-mock": "30.5.0"
+        "jest-mock": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.5.0.tgz",
-      "integrity": "sha512-jEmgmgJEobJ3zEhDOGp1VAJ6JkoVelpS8uZ1ae1Ul/5lP78UKJKmmU0lciJwd6JdnqOXHaaS/QCKwbf1dHI9MA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.5.1.tgz",
+      "integrity": "sha512-uOGd40P/COyUp9xHf5jeGiGJC2/ANg+2+Tk9/xN5/LxmlY/r/gxsPrx3DTEtaRZsLAX4wgNSLEDELZ5bmVs2bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.5.0",
-        "jest-snapshot": "30.5.0"
+        "expect": "30.5.1",
+        "jest-snapshot": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.5.0.tgz",
-      "integrity": "sha512-5j0ztPxSy3McUJihjkDdCyCfjvT2hxykFTWsgEBZKB8qsw9ALdCiGTpTRH5gnf/d+qI4SflYUJ0dWNbzjQCWbA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.5.1.tgz",
+      "integrity": "sha512-WcRWhHQdTMRDpyWKZ/6MINBmovI7zeD+bL8wFjCncRV3NQOwKy1X45IfyblfHR4k/XciIlNEdFL9QjFO+HNKOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1371,18 +1371,18 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.5.0.tgz",
-      "integrity": "sha512-sg8xIbYwe5GdB/vT3/0qrDIpO7Ov9mazHi++M95uynmDKEZ70G1r169AWct73H07VrTZhrz1SJEfLtjYv8tE3A==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.5.1.tgz",
+      "integrity": "sha512-rEkV6YzpBXo/L9cnj2ibyuYZuyGiNWaPUsyCu3HYJbqCV4jnEiKmf7hId20z8eKjZ0JQ9jtIYKxRSmYB/OYSsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "30.5.0",
-        "jest-mock": "30.5.0",
-        "jest-util": "30.5.0"
+        "jest-message-util": "30.5.1",
+        "jest-mock": "30.5.1",
+        "jest-util": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1399,16 +1399,16 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.5.0.tgz",
-      "integrity": "sha512-h7eJx534czwL8lQMYB0hwLT4/HquO8EX/RtYL7RNUHyUyWWVciYjoudN4Ns5JmNvn2/jh0Vm9UstZjEzJJ5EsQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.5.1.tgz",
+      "integrity": "sha512-VhqvQ251XIC7pk46YymI3HCeBLOdvriDw9zibekodAHEwoVvbVVgpU5H13GvmyOAzxtZCfsm1uvzqkaqJf2I+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.5.0",
-        "@jest/expect": "30.5.0",
-        "@jest/types": "30.5.0",
-        "jest-mock": "30.5.0"
+        "@jest/environment": "30.5.1",
+        "@jest/expect": "30.5.1",
+        "@jest/types": "30.5.1",
+        "jest-mock": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1445,17 +1445,17 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.5.0.tgz",
-      "integrity": "sha512-FEAuusWm+PUOn9ydjaHhpOpyPmS6IbGE04HaKTuUI4zd8eqYZiXiNLoCsdCog/l2XnNj53E9pFy64UltcvfJKg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.5.1.tgz",
+      "integrity": "sha512-RbUXIfv85KxitJn4l3MpAoMilkvXe2QCO5lXxHWftywo/VdZ5vkEoHRDgphcxP6qmoIkUaN8/UZj6NhdkIFdJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.5.0",
-        "@jest/test-result": "30.5.0",
-        "@jest/transform": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/console": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
         "@jridgewell/trace-mapping": "^0.3.31",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -1468,9 +1468,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-worker": "30.5.0",
+        "jest-message-util": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-worker": "30.5.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1585,13 +1585,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.5.0.tgz",
-      "integrity": "sha512-iWQtIsi2dRsO2oWzVceOeynuRJiYTW8gsDVp5wFQ02ipHluQsNgBpasWSHiawVxukIlsGLdCtCSbIEK7fPtpvQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.5.1.tgz",
+      "integrity": "sha512-V3wnxNtiVmw5PPVg433Cn3VdXnsOeu/ofLw3KC04Bn2y1wIlU5kozXQn48rhrgj/02LrCVtntTEF1yBha0XSUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -1617,14 +1617,14 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.5.0.tgz",
-      "integrity": "sha512-9IlPqUzUMkVDmoDqSSrVVLroVotgN3hTUPWPwq24XWXhh1Zpg915RXZ5pgRJ/7j4YE/kng5nqjSn4p3S68SZJA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.5.1.tgz",
+      "integrity": "sha512-A/1S6ZBdpic50E0pxLgvaB9XNPL4k7AksmG69OO2oiotxciWZwHkbOec+qbIi+uUtIIByOVlXJUl97oZUsz+Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/console": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -1633,15 +1633,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.5.0.tgz",
-      "integrity": "sha512-TXlvSDIVv482b83hD8A8WtxDJEmGF47f60W6jRXOQL0Isfs3hKtk4rZIm9R/jLzAibg8+c56y+Q00BQs8R7Xcg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.5.1.tgz",
+      "integrity": "sha512-SHcPnrjdVRYJv6y6l4JUTy4Jccu7zmO6BmiOfOA34UiVBto22s19WiDC0A/2qfM7MWB/qdcoqfSIRMitpjTT4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.5.0",
+        "@jest/test-result": "30.5.1",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.5.0",
+        "jest-haste-map": "30.5.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1649,23 +1649,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.5.0.tgz",
-      "integrity": "sha512-n1cYhoByyULEIXi64wbT4Lq91qeT1E6bwpM//sprFXhw955qaiHTdAmy1c1rNFGB6fCf1J+nxDUSf3RGwgZP5A==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.5.1.tgz",
+      "integrity": "sha512-EDnDhn0jleU9ZhpVoA4gvqw+Ev0iw/r5upNT2b79RiwiaTiYAMMhvNJP3lmocjIe5J2ZkoNr0B3K/J6O5GIm4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "@jridgewell/trace-mapping": "^0.3.31",
         "babel-plugin-istanbul": "^8.0.0",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.5.0",
+        "jest-haste-map": "30.5.1",
         "jest-regex-util": "30.5.0",
-        "jest-util": "30.5.0",
+        "jest-util": "30.5.1",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
         "write-file-atomic": "^5.0.1"
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.5.0.tgz",
-      "integrity": "sha512-s1N+79S4Yp9ZgklCauZXi+YPJdCdtStNYQT32stuD6EeQaIBGHoUfyj2P0YWy8RmuQfaJboO+ulxEvEheR/POQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.5.1.tgz",
+      "integrity": "sha512-LvVYn83nnXPl+Rg98nvcFgjx6nRMTArhSn6RAX/w3ELn54S8A42TYZvsCMdGUqTM8S0wyXbtlQdU6Hi6dykj9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4087,13 +4087,13 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.5.0.tgz",
-      "integrity": "sha512-PrhPHlKC+MsLnuNzgIH/y1dkz1f6cSfKWaQeaG8WxLMuG44dYWQ8E9uRrsBbAGCU/3+BEFYPN4d6G3Zc5Y+waA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.5.1.tgz",
+      "integrity": "sha512-ge1xUVZS91ml09YRMgRGgeKJ4YJpcOiuwteAxFBYLugQyp7cRw+hHej6Ho0vPjvLrjq60bb7JPHH9LAMA1/krA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.5.0",
+        "@jest/transform": "30.5.1",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^8.0.0",
         "babel-preset-jest": "30.5.0",
@@ -4299,9 +4299,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
-      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5588,9 +5588,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.416",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
-      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
+      "version": "1.5.421",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.421.tgz",
+      "integrity": "sha512-cUhfpHQy+PGbt+X90DMcAVazDCziIZr73hpxD4LRs4BGQoJCifPzTfQWa7S6c+uhokTOBe8tot09GBSEO6c9LA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6834,18 +6834,18 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.5.0.tgz",
-      "integrity": "sha512-8fiMWcEjPU7B9nErC4FtFcCzf2tC6I75Qf7m8wzBAWC2taZmcno3yAFEjIQL34SwoGZNgPf63UDiJLyh4SMPaw==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.5.1.tgz",
+      "integrity": "sha512-m8YrYgvKe9+9gEnWEuKz+qCGfHqkrff7PPfyDnOFkjsfYRKqiYyOxDFMFieCGAuhtk/VNm63tvNgKZVzVy+Hvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.5.0",
+        "@jest/expect-utils": "30.5.1",
         "@jest/get-type": "30.5.0",
-        "jest-matcher-utils": "30.5.0",
-        "jest-message-util": "30.5.0",
-        "jest-mock": "30.5.0",
-        "jest-util": "30.5.0"
+        "jest-matcher-utils": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-mock": "30.5.1",
+        "jest-util": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8560,16 +8560,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.5.0.tgz",
-      "integrity": "sha512-HeFeOUEKh5gjnp1rjuSCse8Dhj0Y3KA8lsZ3azr4Wnq1nCxwMBu35MDc9mp8iblZxmeAz6wV4P241tyUB7J2Ew==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.5.1.tgz",
+      "integrity": "sha512-3qrR8+ZXFnn7y0H2yjWQNkGGBLBY4zTRoTMAq9zJcgwLLtlyonfsCLviIXK9xuE2KgIyM+M36AFcoK2DgFR36w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/core": "30.5.1",
+        "@jest/types": "30.5.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.5.0"
+        "jest-cli": "30.5.1"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -8587,14 +8587,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.5.0.tgz",
-      "integrity": "sha512-dq1x8JiEnHkJDxxOrF6UJDivBRAQMwAa5tzr+VX3um0SfyMFseUPQUbe51wLwggfoa5h/EmOtSpdJxxkzSlNRQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.5.1.tgz",
+      "integrity": "sha512-0+bvMM/ENhDI29Z8q1r4HxiDIi4G5tnBmSw4esfPQoj9q8Nik7KIyuxHkTVnnniJQf05SxpGaKDQ+4h28ynGPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.5.0",
+        "jest-util": "30.5.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -8602,29 +8602,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.5.0.tgz",
-      "integrity": "sha512-T3v7uM4wwCu+RQicjsAWCgoL3CiyuX3THSKwv2uMb9N2bMUgb+HfwDWEUma85vOGbvQNQ/YfoCXF1OCZot0ZEw==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.5.1.tgz",
+      "integrity": "sha512-NgliezXQ6yznqR4W5Gqw++0cZSbBZlF0NknNIAE5VmSJKWOtmWJmWnBq3TSkUOVBTPrT7FGGhVdA8DLWnxo2Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.5.0",
-        "@jest/expect": "30.5.0",
-        "@jest/test-result": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/environment": "30.5.1",
+        "@jest/expect": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.5.0",
-        "jest-matcher-utils": "30.5.0",
-        "jest-message-util": "30.5.0",
-        "jest-runtime": "30.5.0",
-        "jest-snapshot": "30.5.0",
-        "jest-util": "30.5.0",
+        "jest-each": "30.5.1",
+        "jest-matcher-utils": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-runtime": "30.5.1",
+        "jest-snapshot": "30.5.1",
+        "jest-util": "30.5.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.5.0",
+        "pretty-format": "30.5.1",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -8634,21 +8634,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.5.0.tgz",
-      "integrity": "sha512-QHZMiy32x2K+NzJ1AuuoCAVc1Y5co0VXib3R7kD9MWcWFflzsD1eJN0wR+mkNlM+ts7C+Bjz0oOoFE5IiHylCg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.5.1.tgz",
+      "integrity": "sha512-uwNYepWgaNBCplm42fCIUZTf/tIEHIy5AYvx7eL1BrwIgyjPt+2poouR23UO2yopIP+kV8oZFHfv+l4pg/8prQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.5.0",
-        "@jest/test-result": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/core": "30.5.1",
+        "@jest/test-result": "30.5.1",
+        "@jest/types": "30.5.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-validate": "30.5.0",
+        "jest-config": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -8667,33 +8667,33 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.5.0.tgz",
-      "integrity": "sha512-gYQl2FqYgiVpyuB7DutBIbJRWaq5VcHdzOXJJ51HNa8J5JrsZehIlzNFW0/9s5uvvcbzM5/LTUizYSbsFErv+w==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.5.1.tgz",
+      "integrity": "sha512-L8PKM2X/ngG8PxfLMqglKGZjylPgw84bVPUlMY9W/o76TnLqPWrmQgsaT0HrheGdRtpGE5FbmREA0Kvb+Qx5gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.5.0",
         "@jest/pattern": "30.5.0",
-        "@jest/test-sequencer": "30.5.0",
-        "@jest/types": "30.5.0",
-        "babel-jest": "30.5.0",
+        "@jest/test-sequencer": "30.5.1",
+        "@jest/types": "30.5.1",
+        "babel-jest": "30.5.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.5.0",
+        "jest-circus": "30.5.1",
         "jest-docblock": "30.5.0",
-        "jest-environment-node": "30.5.0",
+        "jest-environment-node": "30.5.1",
         "jest-regex-util": "30.5.0",
-        "jest-resolve": "30.5.0",
-        "jest-runner": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-validate": "30.5.0",
+        "jest-resolve": "30.5.1",
+        "jest-runner": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.5.0",
+        "pretty-format": "30.5.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -8802,16 +8802,16 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.5.0.tgz",
-      "integrity": "sha512-QjCfDMwdPFvLxTQmS4/Dswx3PUCiqmSXVLGljMC3SU7YG1qHVoR6b86IH/O2G9k9OMyKXz2vS2Q60VnAozNDwA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.5.1.tgz",
+      "integrity": "sha512-e3cNNMpv8Kh20MjjphTXs+3Vz7DQyLM1nft7KJhnh46atFhjVJRa+0Hq0beywuwsACtMQUBihQkFl8zxb7gt1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/diff-sequences": "30.5.0",
         "@jest/get-type": "30.5.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.5.0"
+        "pretty-format": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8831,49 +8831,49 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.5.0.tgz",
-      "integrity": "sha512-NiMFNhRygJEFqYNt8pnkxppUF6CR486GEpt9rSU6lPBf7KeccaOL0zbjxG8fgJgD//6e7zYdssnlt6j+1kI31A==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.5.1.tgz",
+      "integrity": "sha512-S1af0TU4v1EZ/AUlkFs/sxf/5KGsbAT9kRgdyoMX/x72y7C8ZEgETE5o1TPnbKRnrbprc5FR/moYLfdRmqEjsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "chalk": "^4.1.2",
-        "jest-util": "30.5.0",
-        "pretty-format": "30.5.0"
+        "jest-util": "30.5.1",
+        "pretty-format": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.5.0.tgz",
-      "integrity": "sha512-bTc79ywKLz0ogbT3JIYuEhgWV4Ffd/cJe06co4v8CyRtlmju8x5gokMlGFR8ARWhmk5SnbDRxmf50XWnlZVhDg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.5.1.tgz",
+      "integrity": "sha512-LrPj3sPMjsQoOB3jrb8p/sa+XkSFNKo60TTsyc+EB2kxQJHgbwElpXnx1yX25fdFn5958FIObRtcLSHyV8VIAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.5.0",
-        "@jest/fake-timers": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/environment": "30.5.1",
+        "@jest/fake-timers": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
-        "jest-mock": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-validate": "30.5.0"
+        "jest-mock": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.5.0.tgz",
-      "integrity": "sha512-0FStogBslBVOEqTOJr4oXMtFitmrWp9WscG6Gbns88i0YAuMXijCT2G5VMfg/HCR4QAnL+OF2C2ednag+HlDuA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.5.1.tgz",
+      "integrity": "sha512-VIFgt67jW480YDxKfEv9IYQKrFpYt7bOCMn3VsnjK7AK9qo7p6acpnA1DHwsVOULE3dTaYew/6JaTD/d0VDHoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "@parcel/watcher": "^2.6.0",
         "@types/node": "*",
         "anymatch": "^3.1.3",
@@ -8881,8 +8881,8 @@
         "fdir": "^6.5.0",
         "graceful-fs": "^4.2.11",
         "jest-regex-util": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-worker": "30.5.0",
+        "jest-util": "30.5.1",
+        "jest-worker": "30.5.1",
         "picomatch": "^4.0.3"
       },
       "engines": {
@@ -8890,50 +8890,50 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.5.0.tgz",
-      "integrity": "sha512-Mq11ceAkNR250Iv45RoOwuG9fb4kYbJ02qoyL7A0nCI8FV5+aG/THmcEUx5uR2dNSa4KOtz+xBKrJ8cZPhPpuQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.5.1.tgz",
+      "integrity": "sha512-gt4GT2aWgEoCNTcBe4rqS74xTIUJxi+UD9SNSu9aOk5LmTEd6fS5KSTmAKAfitCCktQHNN+upUuL6EkBfFbMDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.5.0",
-        "pretty-format": "30.5.0"
+        "pretty-format": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.5.0.tgz",
-      "integrity": "sha512-EfaYMC9f9ds7fahB/LYFTgd1Z2RS9Vpm2e46gazij0onkpoQG7Daq+MLm8/gQVqWwRVjL/RNDggbFx9MsrJEmQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.5.1.tgz",
+      "integrity": "sha512-aroZVqwOz/wC2y6pC+obgFWKV9viaQWQTTSB6W5H55+egtUczIfXR/rxExTv92xD/ADYwpqaYfVWx1aqwKg7FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.5.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.5.0",
-        "pretty-format": "30.5.0"
+        "jest-diff": "30.5.1",
+        "pretty-format": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.5.0.tgz",
-      "integrity": "sha512-dBYMhplGfspKaCnVk9TUy1cZnknWubpuPNEputjz0YJk1G/92R45rn45BvbPMPMtC5LVcIdxJGPOaOSQTiuzJw==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.5.1.tgz",
+      "integrity": "sha512-UdQlLdd9wL/Ys7xRErckqwD6wPlSZYueosSWuHc1r2ztGLwlgPvtSJq2+BPEgaEY13WLvfFbmhTj8pba0Sd1jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-util": "30.5.0",
+        "jest-util": "30.5.1",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.5.0",
+        "pretty-format": "30.5.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -8942,16 +8942,16 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.5.0.tgz",
-      "integrity": "sha512-bP5MHZpkYrV7xpV+yvhl36DPcXoEmTR57Un5EACcdVpMY7mpkDefCBq+V4mhcjE/3rwUajT6OTrcJTN7EwN1BA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.5.1.tgz",
+      "integrity": "sha512-9fVjc3leUpGID2/by/LU4Dvdcp7PFh9LlxS3QRWK3ABm+KtvEVsG/AEGeLY3gKOZsjkBxyfwGltoAVlW7dygHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/expect-utils": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
-        "jest-util": "30.5.0"
+        "jest-util": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8968,17 +8968,17 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.5.0.tgz",
-      "integrity": "sha512-NFvQWJ4G7e2kN5712iG+12Xr325NRFGAIhovrwLfgq5Oqd4bFHITw4CzcFkZGp1GTCqemC4v1l8/yZzedKZkjw==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.5.1.tgz",
+      "integrity": "sha512-wprhLejRtwN6h8ZgaqC0eYjGJ1uMdGPT/+b3eFncbG4NWuuP9QL+vWwRinu9waw7hkOLcpMJGVJAMgBwsPssMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-validate": "30.5.0",
+        "jest-haste-map": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-validate": "30.5.1",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.12.1"
       },
@@ -8987,47 +8987,47 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.5.0.tgz",
-      "integrity": "sha512-TnSBAp3wGOnqXBmLT3OXtJkugw6Vj2KU0IPde2EJmbGns/QMoNlkauJ7jZ8KYaxONSpx0o4pUvi+u1Q/LSk3Pg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.5.1.tgz",
+      "integrity": "sha512-JKpXGONDcTaunrNVn8KCl6qAnwl06jIkvv70lhq0Ze47lsPx9sH5HoeEUiXX6iFGnliHN/qpIbQ0l38wrVmXaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "30.5.0",
-        "jest-snapshot": "30.5.0"
+        "jest-snapshot": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.5.0.tgz",
-      "integrity": "sha512-Q6Yt+1LvXvEstvru6sQLT7OQYC77VNl6dK0KEvBkeOHgThmXDqNp3Ox9TglDWFHU85pemqTNdKwxfnmO3vgrdA==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.5.1.tgz",
+      "integrity": "sha512-FPlQE4+mwnFxXmpPrSi836KV2ZzvK1g6/nPCT8o5BcoDUUNJQeHo1/Qdkoe/QeoL4M7OeJpbnGUhYKhC1VMdaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.5.0",
-        "@jest/environment": "30.5.0",
+        "@jest/console": "30.5.1",
+        "@jest/environment": "30.5.1",
         "@jest/source-map": "30.5.0",
-        "@jest/test-result": "30.5.0",
-        "@jest/transform": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.5.0",
-        "jest-environment-node": "30.5.0",
-        "jest-haste-map": "30.5.0",
-        "jest-leak-detector": "30.5.0",
-        "jest-message-util": "30.5.0",
-        "jest-resolve": "30.5.0",
-        "jest-runtime": "30.5.0",
-        "jest-util": "30.5.0",
-        "jest-watcher": "30.5.0",
-        "jest-worker": "30.5.0",
+        "jest-environment-node": "30.5.1",
+        "jest-haste-map": "30.5.1",
+        "jest-leak-detector": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-resolve": "30.5.1",
+        "jest-runtime": "30.5.1",
+        "jest-util": "30.5.1",
+        "jest-watcher": "30.5.1",
+        "jest-worker": "30.5.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -9035,19 +9035,19 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.5.0.tgz",
-      "integrity": "sha512-VTRz0sRIw2EISeHigx1O+CMuwoG4+RKJjF8dp8okzFaDNQEcv5Mw0h5QW8VJXgb2CRF4gZIjSEBb2jdzXPagFQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.5.1.tgz",
+      "integrity": "sha512-UB88+NRkK2Tw/OqV7dofYcyiUGrVZtD41k/N0xQOs9fG//57XHK7JLWG52HD1UYpUAhjK4xm6DBvFX3yWudsMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.5.0",
-        "@jest/fake-timers": "30.5.0",
-        "@jest/globals": "30.5.0",
+        "@jest/environment": "30.5.1",
+        "@jest/fake-timers": "30.5.1",
+        "@jest/globals": "30.5.1",
         "@jest/source-map": "30.5.0",
-        "@jest/test-result": "30.5.0",
-        "@jest/transform": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/test-result": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.2.0",
@@ -9055,13 +9055,13 @@
         "es-module-lexer": "^2.1.0",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.5.0",
-        "jest-message-util": "30.5.0",
-        "jest-mock": "30.5.0",
+        "jest-haste-map": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-mock": "30.5.1",
         "jest-regex-util": "30.5.0",
-        "jest-resolve": "30.5.0",
-        "jest-snapshot": "30.5.0",
-        "jest-util": "30.5.0",
+        "jest-resolve": "30.5.1",
+        "jest-snapshot": "30.5.1",
+        "jest-util": "30.5.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -9154,9 +9154,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.5.0.tgz",
-      "integrity": "sha512-pZWETdcqmKve9MDTE/AX6RaeAbRhzKhhAXGozAW8Pg2FfOSdUrQ/7D+VdwE3fLQsqjpITXJVQvYVZoMEzrUl0Q==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.5.1.tgz",
+      "integrity": "sha512-cNWFdSb5xuDGl8hKkAZJ3YtI/PzHpAPFV+HUXWIOG8rMhpDTLVbvAc2d2wRicoYw2wGsJGLaurJT6BLC97bLXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9165,20 +9165,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.5.0",
+        "@jest/expect-utils": "30.5.1",
         "@jest/get-type": "30.5.0",
-        "@jest/snapshot-utils": "30.5.0",
-        "@jest/transform": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/snapshot-utils": "30.5.1",
+        "@jest/transform": "30.5.1",
+        "@jest/types": "30.5.1",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.5.0",
+        "expect": "30.5.1",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.5.0",
-        "jest-matcher-utils": "30.5.0",
-        "jest-message-util": "30.5.0",
-        "jest-util": "30.5.0",
-        "pretty-format": "30.5.0",
+        "jest-diff": "30.5.1",
+        "jest-matcher-utils": "30.5.1",
+        "jest-message-util": "30.5.1",
+        "jest-util": "30.5.1",
+        "pretty-format": "30.5.1",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -9187,13 +9187,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.5.0.tgz",
-      "integrity": "sha512-lzU4aGUWaS+2X/B0CmgheDasfnsVlRfZh/rNQxB9b9s8cSYUq5BcqdQA95ld+KqJXBUVVt1sqnMQ2T3OxIalmg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.5.1.tgz",
+      "integrity": "sha512-yKuxmNy2rSbTXw+3SIPanJo+nV4/BS1p26v44IYBFMsswSQySfMMcPHErnOncda7i9HEz0q605rIhSTBVgrZTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -9205,18 +9205,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.5.0.tgz",
-      "integrity": "sha512-N/hsPYKgBSzBeVZ2RHCs3yvBbTZNPX7Be8q33zhyo/yeFneBL1swzly31LYU4LJ3zJM9e8TxSM8IYLo2SDJZYQ==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.5.1.tgz",
+      "integrity": "sha512-i/buJ56wTpxihE93hQYNMfdOThS87+HGvLZzZJmU4xggPcdTYQq051iwALLCHp3q+SkCGH+EFejQZz5EbBSkkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/types": "30.5.1",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.5.0"
+        "pretty-format": "30.5.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -9236,19 +9236,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.5.0.tgz",
-      "integrity": "sha512-ujjnEoL4Uu+Swu3WRwYenWMB9JMEiD2T3OypnveMJ64S/1r/5G8eC4OQ1wEOgYWQqMi+mT+buzccflCHr/XJ9Q==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.5.1.tgz",
+      "integrity": "sha512-+FHJ7C+S7b3ySfhA1aFmoa6TztsnwZVv84ycPRn0tVN93np2EU4b8C/KadqA3l6igdjgLBTnUotab9ER0HLG8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.5.0",
-        "@jest/types": "30.5.0",
+        "@jest/test-result": "30.5.1",
+        "@jest/types": "30.5.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.5.0",
+        "jest-util": "30.5.1",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -9256,15 +9256,15 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.5.0.tgz",
-      "integrity": "sha512-7kFk/607EoynNHLJa20daivkElM+c9PrCLduYy6AlMkYrXbh5TmVtW1BLXE05Y8baAFsJHMoC3xs2QRRTotwLw==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.5.1.tgz",
+      "integrity": "sha512-Cbxh5v7AoLuFRmFJSM4/aHdQ68rjXvUWr716EE0Dh3I7T+T/3FgFKhOERGXHcU2Meftq9+9zxPM3TSNyI9D+HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.5.0",
+        "jest-util": "30.5.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -12679,9 +12679,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.5.0.tgz",
-      "integrity": "sha512-mzNzBErpHwM0zpmWS7ExOv62yhQhvd546nUuFqVR0dmnJB59tfrw9sjDF0DJknwsr59OXP0buwJ7PaKguczHSg==",
+      "version": "30.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.5.1.tgz",
+      "integrity": "sha512-byhRAPguVKMQIj4kjJwJ5lAskVhfuiSdiYl/aLTWpgkGEmic2jYhJh1yE9ih8Ox44Xg9ccCT11/S6QrzSJuNrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,9 @@ The queue is named rather than derived from a Consumer group, because what ident
 the Key it is bound under rather than the exchange it belongs to. It is also durable, so what is
 published while nothing is consuming is held rather than dropped.
 
+Over a [sharded connection](#sharded-connection) they behave as the rest does: `route` publishes
+to one shard, and `subscribe` consumes the queue on every one of them.
+
 ### Example
 
 ```javascript

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -64,12 +64,20 @@ class Channel {
     await this.#every((channel) => channel.subscribe(queue, group, consumer))
   }
 
+  async bound (exchange, queue, key, consumer) {
+    await this.#every((channel) => channel.bound(exchange, queue, key, consumer))
+  }
+
   async send (queue, buffer, options) {
     await this.#one((channel) => channel.send(queue, buffer, options))
   }
 
   async publish (exchange, buffer, options) {
     await this.#one((channel) => channel.publish(exchange, buffer, options))
+  }
+
+  async route (exchange, key, buffer, options) {
+    await this.#one((channel) => channel.route(exchange, key, buffer, options))
   }
 
   async fire (queue, buffer, options) {

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -718,3 +718,36 @@ async function getCreatedChannels () {
 
   return await Promise.all(promises)
 }
+
+describe('routed', () => {
+  const exchange = generate()
+  const queue = generate()
+  const key = generate()
+  const buffer = randomBytes(8)
+  const consumer = jest.fn()
+
+  /** @type {jest.MockedObject<comq.Channel>[]} */
+  let channels
+
+  beforeEach(async () => {
+    channel = await create(connections, type)
+    channels = await getCreatedChannels()
+  })
+
+  it('should bind using all channels', async () => {
+    await channel.bound(exchange, queue, key, consumer)
+
+    for (const chan of channels) {
+      expect(chan.bound).toHaveBeenCalledWith(exchange, queue, key, consumer)
+    }
+  })
+
+  it('should route to a single channel', async () => {
+    await channel.route(exchange, key, buffer)
+
+    const used = channels.filter((chan) => chan.route.mock.calls.length > 0)
+
+    expect(used).toHaveLength(1)
+    expect(used[0].route).toHaveBeenCalledWith(exchange, key, buffer, undefined)
+  })
+})


### PR DESCRIPTION
Releases #270 and #267.

`semantic-release` will cut a **patch** off the `fix:` — `0.17.0` → `0.17.1`. The jest bump is `chore(deps-dev)` and moves nothing on its own.

## What ships

**#270 — routing over a sharded connection.** `route` and `bound` reached `source/channel.js` and not `source/shards/channel.js`, so a connection to more than one broker answered that they are not functions. `assert()` switches to the sharded channel on the second URL, so anything using a shard set hit it on its first routed call. They now follow the rule the pair beside them does — *send to one, receive from all*: `route` → `#one` as `publish` does, `bound` → `#every` as `subscribe` does.

Reproduced before it was fixed, on both levels: a unit test against the real `shards/channel.js`, and a scenario over the two brokers the compose file already runs. That scenario is what would have caught it — every other routed one uses a single broker, which is the path that worked.

**#267 — jest 30.5.0 → 30.5.1**, a dev dependency.

## Verified on the branch

- `npm test` — 425 unit tests on jest 30.5.1, `standard` clean.
- `npm run features:fast` — 36 scenarios, 229 steps.

Wanted by [toa-io/toa#1107](https://github.com/toa-io/toa/pull/1107), where a region may name more than one broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)