### PR TITLE
chore(deps-dev): bump js-yaml to 4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -5094,9 +5094,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -6617,9 +6617,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves dependabot alert [#94](https://github.com/toa-io/comq/security/dependabot/94) — [GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh) / CVE-2026-84375, high, 7.5.

`js-yaml`'s `maxTotalMergeKeys` does not count empty merge sources, so a small document can make the loader do `O(N*K)` work without ever reaching the limit. Patched in 4.3.2.

Three copies were on 4.3.1, all development-only and all transitive:

| dependent | range |
| --- | --- |
| `eslint` (via `standard`) | `^4.1.0` |
| `@eslint/eslintrc` | `^4.1.0` |
| `cosmiconfig` (via `semantic-release`, `husky`) | `^4.1.0` |

Every range admits 4.3.2, so `package.json` is untouched and only the lockfile moves — 9 lines, `js-yaml` and nothing else.

The other two copies in the tree are already outside the vulnerable ranges and were left alone: 3.15.2 under `@istanbuljs/load-nyc-config` (patched 3.x) and the direct devDependency `js-yaml@5.4.1`.

`npm test` passes (standard + 425 tests), `npm audit` reports 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)