### PR TITLE
ci: run the feature suite on every branch

### DIFF
--- a/.github/workflows/features.yaml
+++ b/.github/workflows/features.yaml
@@ -1,19 +1,30 @@
-name: Dev
+name: Features
 
 on:
   push:
-    branches:
-      - dev
+    branches-ignore:
+      # tested by the release workflow before it publishes
+      - release
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   features-fast:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       HUSKY: 0
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v7


### PR DESCRIPTION
The fast feature suite ran only on `push` to `dev` — that is, only *after* a merge. A break was therefore discovered on the branch everything else is built from, and a pull request was reviewed and merged with nothing having run against it. Both of the last two dependency pull requests needed a manual local run to make up for it.

It now runs on every push, so a branch is covered before its pull request is merged.

### Forks are deliberately not covered

`pull_request:` would have been the obvious trigger, and it is the wrong one here. A fork's pull request runs *its own copy* of this workflow file on our runners, so anyone could put arbitrary steps in it. The exposure is real even though it is bounded (the repository is public, so runner minutes are free, and GitHub gives a fork's run a read-only token and no secrets; the approval policy is `first_time_contributors`, so a stranger's first pull request needs a maintainer's click, but every pull request after their first contribution lands runs unattended).

None of that buys anything here, because every branch that matters — mine, dependabot's — is pushed to this repository rather than to a fork. `push` covers all of them and runs no fork code at all. An outside contributor's pull request gets no CI, exactly as today, so nothing is lost.

`release` is excluded from the trigger: `release.yaml` already runs `npm test` on that branch before publishing.

### Alongside the trigger

Four things that cost nothing and were missing:

- `permissions: contents: read` — the job only reads the repository. The org default is `write`.
- `persist-credentials: false` on the checkout, as `release.yaml` already does — nothing here pushes.
- `timeout-minutes: 15` — the suite takes about 2 minutes, so a hang no longer occupies a runner for 6 hours.
- `concurrency` with `cancel-in-progress` — pushing a branch fifty times leaves one run, not fifty.

### Renamed

`dev.yaml` → `features.yaml`, `name: Dev` → `Features`. The old name described the trigger, and the trigger is no longer `dev`. Past runs stay in the Actions history under the old name.

### Verified

Pushing this branch ran the workflow on this branch — the change tests itself. `actionlint` is clean on both workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)