### PR TITLE
feat: a call reaches the one connection holding its key, and a request can end

### DIFF
--- a/features/rpc.call.feature
+++ b/features/rpc.call.feature
@@ -53,12 +53,11 @@ Feature: Calls under a key
     When the consumer calls `slow` under the `a` key
     Then the call is refused as unroutable
 
-  Scenario: A key is held by one connection at a time
+  Scenario: A second holder waits for the key
     Given a holder on another connection answering `echo` under the `a` key
     When a second holder on another connection holds `echo` under the `a` key
-    Then the second holder is refused
+    Then the second holder finds the key taken
     When the first holder disconnects
-    And a second holder on another connection holds `echo` under the `a` key
     Then the second holder holds the key
     When the consumer calls `echo` under the `a` key
     Then the consumer receives the reply

--- a/features/rpc.call.feature
+++ b/features/rpc.call.feature
@@ -1,0 +1,70 @@
+Feature: Calls under a key
+
+  A call reaches the one connection holding its key. A call under a key nobody holds is refused
+  at once, and a holder that stops withdraws its key before it finishes what it holds.
+
+  Background:
+    Given an active connection to the broker
+
+  Scenario: Answered by the holder of the key
+    Given a holder answering `sums` under the `a` key:
+      """
+      ({ a, b }) => a + b
+      """
+    When the consumer calls `sums` under the `a` key with:
+      """yaml
+      a: 1
+      b: 2
+      """
+    Then the consumer receives the reply:
+      """yaml
+      3
+      """
+
+  Scenario: Answered by the holder of that key only
+    Given a holder answering `names` under the `a` key:
+      """
+      () => 'a'
+      """
+    And a holder answering `names` under the `b` key:
+      """
+      () => 'b'
+      """
+    When the consumer calls `names` under the `b` key
+    Then the consumer receives the reply:
+      """yaml
+      b
+      """
+
+  Scenario: Refused when nobody holds the key
+    Given a holder answering `names` under the `a` key:
+      """
+      () => 'a'
+      """
+    When the consumer calls `names` under the `c` key
+    Then the call is refused as unroutable
+
+  Scenario: A sealed holder answers what it holds and refuses what follows
+    Given a holder on another connection answering `slow` under the `a` key in 500ms
+    When the consumer calls `slow` under the `a` key
+    And after 100ms
+    And the holder is sealed
+    Then the consumer receives the reply
+    When the consumer calls `slow` under the `a` key
+    Then the call is refused as unroutable
+
+  Scenario: A second holder waits for the key
+    Given a holder on another connection answering `echo` under the `a` key
+    When a second holder on another connection holds `echo` under the `a` key
+    Then the second holder waits for the key
+    When the first holder disconnects
+    Then the second holder holds the key
+    When the consumer calls `echo` under the `a` key
+    Then the consumer receives the reply
+
+  Scenario: A caller stops waiting for a holder that is gone
+    Given a holder never answering `void` under the `a` key
+    When the consumer calls `void` under the `a` key with a 1000ms timeout
+    And after 100ms
+    And the silent holder's connection is lost
+    Then the consumer stops waiting

--- a/features/rpc.call.feature
+++ b/features/rpc.call.feature
@@ -53,18 +53,20 @@ Feature: Calls under a key
     When the consumer calls `slow` under the `a` key
     Then the call is refused as unroutable
 
-  Scenario: A second holder waits for the key
+  Scenario: A key is held by one connection at a time
     Given a holder on another connection answering `echo` under the `a` key
     When a second holder on another connection holds `echo` under the `a` key
-    Then the second holder waits for the key
+    Then the second holder is refused
     When the first holder disconnects
+    And a second holder on another connection holds `echo` under the `a` key
     Then the second holder holds the key
     When the consumer calls `echo` under the `a` key
     Then the consumer receives the reply
 
-  Scenario: A caller stops waiting for a holder that is gone
+  Scenario: A caller stops waiting for a holder that crashed
     Given a holder never answering `void` under the `a` key
     When the consumer calls `void` under the `a` key with a 1000ms timeout
     And after 100ms
-    And the silent holder's connection is lost
+    And the silent holder crashes
     Then the consumer stops waiting
+    And a call to `void` under the `a` key is refused within 10 seconds

--- a/features/rpc.call.recovery.feature
+++ b/features/rpc.call.recovery.feature
@@ -1,0 +1,75 @@
+@heavy
+Feature: Calls under a key across failures
+
+  A holder that loses its connection holds its key again once the connection is restored, and a
+  caller's timeout ends its wait whatever the broker is doing.
+
+  Scenario: A holder holds its key again after the broker restarts
+    Given an active connection to the broker
+    And a holder on another connection answering `echo` under the `a` key
+    When the broker has crashed
+    And the broker is up
+    Then a call to `echo` under the `a` key is answered within 60 seconds
+
+  Scenario: A holder holds its key again once the broker lets its silent connection go
+
+    The holder reconnects while the broker still holds the connection that went silent, and with
+    it the key. Its recovery is refused until the broker lets that connection go, and made again.
+
+    Given watchdog interval is set to 2000ms with 60s AMQP heartbeat
+    And a network that can go silent
+    And an active connection to the broker
+    And the connection's failed recoveries are recorded
+    And a holder answering `echo` under the `a` key:
+      """
+      (payload) => payload
+      """
+    When the network goes silent
+    Then the connection is lost within 10 seconds
+    And its recovery is refused while the broker holds the silent connection
+    When the silent connection is let go
+    Then a call to `echo` under the `a` key from another connection is answered within 60 seconds
+
+  Scenario: A call in flight when the broker crashes ends
+    Given an active connection to the broker
+    And a holder on another connection answering `slow` under the `a` key in 2000ms
+    When the consumer calls `slow` under the `a` key
+    And after 200ms
+    And the broker has crashed
+    And the broker is up
+    Then the call ends
+
+  Scenario: A caller stops waiting for a request at its timeout while the broker is down
+    Given an active connection to the broker
+    And a producer replying `echo` queue
+    When the broker has crashed
+    And the consumer sends a request to the `echo` queue with a 1000ms timeout
+    Then the consumer stops waiting within 5 seconds
+
+  Scenario: A caller stops waiting for a call at its timeout while the broker is down
+    Given an active connection to the broker
+    And a holder on another connection answering `echo` under the `a` key
+    When the broker has crashed
+    And the consumer calls `echo` under the `a` key with a 1000ms timeout
+    Then the consumer stops waiting within 5 seconds
+
+  Scenario: A request re-sent after the broker restarts expires at its caller's deadline
+
+    The request is lost with the broker and sent again once the connection is restored, carrying
+    the time its caller has left.
+
+    Given an active connection to the broker
+    When the consumer sends a request to the `resent` queue with a 30000ms timeout
+    And after 200ms
+    And the broker has crashed
+    And the broker is up
+    Then the consumer stops waiting within 40 seconds
+    When a producer counting requests to the `resent` queue
+    Then the producer receives nothing
+
+  Scenario: A call reaches its holder while one of the brokers is down
+    Given an active sharded connection
+    And a holder on another connection answering `echo` under the `a` key
+    When one of the brokers has crashed
+    And the consumer calls `echo` under the `a` key 20 times
+    Then every call is answered

--- a/features/rpc.call.recovery.feature
+++ b/features/rpc.call.recovery.feature
@@ -14,19 +14,19 @@ Feature: Calls under a key across failures
   Scenario: A holder holds its key again once the broker lets its silent connection go
 
     The holder reconnects while the broker still holds the connection that went silent, and with
-    it the key. Its recovery is refused until the broker lets that connection go, and made again.
+    it the key. The holder finds the key taken until the broker lets that connection go, and
+    claims it then.
 
     Given watchdog interval is set to 2000ms with 60s AMQP heartbeat
     And a network that can go silent
     And an active connection to the broker
-    And the connection's failed recoveries are recorded
     And a holder answering `echo` under the `a` key:
       """
       (payload) => payload
       """
     When the network goes silent
     Then the connection is lost within 10 seconds
-    And its recovery is refused while the broker holds the silent connection
+    And the holder finds its key taken while the broker holds the silent connection
     When the silent connection is let go
     Then a call to `echo` under the `a` key from another connection is answered within 60 seconds
 

--- a/features/rpc.call.shards.feature
+++ b/features/rpc.call.shards.feature
@@ -15,3 +15,10 @@ Feature: Calls under a key over a sharded connection
     Given a holder connected to broker 0 answering `echo` under the `a` key
     When the consumer calls `echo` under the `b` key
     Then the call is refused as unroutable
+
+  Scenario: A key taken on one broker is held on the other, and on both once it is let go
+    Given a holder connected to broker 0 answering `whom` under the `a` key as `first`
+    When a second holder on another connection holds `whom` under the `a` key as `second`
+    Then the second holder finds the key taken
+    When the first holder disconnects
+    Then every call to `whom` under the `a` key is answered by `second` within 30 seconds

--- a/features/rpc.call.shards.feature
+++ b/features/rpc.call.shards.feature
@@ -1,0 +1,17 @@
+Feature: Calls under a key over a sharded connection
+
+  A call is published to one shard, and a shard where nobody holds the key returns it: it is
+  published on the next one, and refused once every shard has returned it.
+
+  Background:
+    Given an active sharded connection
+
+  Scenario: Answered by a holder on one broker only
+    Given a holder connected to broker 0 answering `echo` under the `a` key
+    When the consumer calls `echo` under the `a` key 20 times
+    Then every call is answered
+
+  Scenario: Refused when nobody holds the key on any broker
+    Given a holder connected to broker 0 answering `echo` under the `a` key
+    When the consumer calls `echo` under the `b` key
+    Then the call is refused as unroutable

--- a/features/rpc.parked.feature
+++ b/features/rpc.parked.feature
@@ -5,13 +5,13 @@ Feature: Parked requests
 
   Scenario: A parked request can still be answered
 
-    A caller is certain of an eventual answer for as long as it is alive, and parking
-    is what keeps that true when no consumer can produce one: the request is not
-    deleted, and it keeps who was asking. Somebody else can answer it, and the caller
-    — still waiting, still holding an exclusive reply queue — receives it.
+    A caller that sets no timeout is certain of an eventual answer for as long as it is
+    alive, and parking is what keeps that true when no consumer can produce one: the
+    request is kept, along with who was asking. Somebody else can answer it, and the
+    caller — still waiting, still holding an exclusive reply queue — receives it.
 
-    This is why there is no request timeout and no way to withdraw a request: either
-    would leave the parked message addressed to a caller that is no longer listening.
+    A caller that sets a timeout trades that for an end to the wait: once it stops
+    waiting, a parked request is addressed to a caller that has gone.
 
     Given a producer failing every request to the `unanswerable` queue
     When a request is sent to the `unanswerable` queue

--- a/features/rpc.timeout.feature
+++ b/features/rpc.timeout.feature
@@ -1,0 +1,19 @@
+Feature: Request timeout
+
+  A caller may say how long it waits for a reply. A request nobody took by then is dropped by the
+  broker; one already taken is still processed, and its reply is discarded.
+
+  Background:
+    Given an active connection to the broker
+
+  Scenario: A caller stops waiting at its timeout
+    Given a producer replying `slow` queue in 1000ms
+    When the consumer sends a request to the `slow` queue with a 200ms timeout
+    Then the consumer stops waiting
+
+  Scenario: A request nobody took in time is never processed
+    When the consumer sends a request to the `later` queue with a 200ms timeout
+    Then the consumer stops waiting
+    When after 300ms
+    And a producer counting requests to the `later` queue
+    Then the producer receives nothing

--- a/features/steps/call.js
+++ b/features/steps/call.js
@@ -30,7 +30,7 @@ Given('a holder on another connection answering {token} under the {token} key',
    * @this {comq.features.Context}
    */
   async function (exchange, key) {
-    this.holder = await holder(this)
+    this.holder = await another(this)
 
     await this.holder.back(exchange, key, echo)
   })
@@ -43,7 +43,7 @@ Given('a holder on another connection answering {token} under the {token} key in
    * @this {comq.features.Context}
    */
   async function (exchange, key, delay) {
-    this.holder = await holder(this)
+    this.holder = await another(this)
 
     await this.holder.back(exchange, key, async (payload) => {
       await timeout(delay)
@@ -60,7 +60,7 @@ Given('a holder connected to broker {number} answering {token} under the {token}
    * @this {comq.features.Context}
    */
   async function (broker, exchange, key) {
-    this.holder = await holder(this, broker)
+    this.holder = await another(this, broker)
 
     await this.holder.back(exchange, key, echo)
   })
@@ -87,14 +87,29 @@ Given('a holder never answering {token} under the {token} key',
     this.silent = connection
   })
 
-When('the silent holder\'s connection is lost',
+When('the silent holder crashes',
+  /**
+   * Its socket is destroyed without a word, as a process that dies leaves it.
+   *
+   * @this {comq.features.Context}
+   */
+  function () {
+    const connection = this.silent
+
+    this.silent = undefined
+
+    connection.on('error', () => undefined)
+    connection.connection.stream.destroy()
+  })
+
+Given('the connection\'s failed recoveries are recorded',
   /**
    * @this {comq.features.Context}
    */
-  async function () {
-    await this.silent.close()
+  function () {
+    this.recoveries = []
 
-    this.silent = undefined
+    this.io.diagnose('error', (error) => this.recoveries.push(error))
   })
 
 When('the consumer calls {token} under the {token} key',
@@ -167,12 +182,12 @@ When('a second holder on another connection holds {token} under the {token} key'
    * @this {comq.features.Context}
    */
   async function (exchange, key) {
-    const second = await holder(this)
-
-    this.locked = false
-    second.diagnose('locked', () => (this.locked = true))
+    const second = await another(this)
 
     this.holding = second.back(exchange, key, echo)
+
+    // asserted on by a later step, and an unhandled rejection would end the run before it
+    this.holding.catch(() => undefined)
   })
 
 When('the first holder disconnects',
@@ -214,12 +229,12 @@ Then('the consumer stops waiting',
     await assert.rejects(this.reply, (error) => error.name === 'TimeoutError')
   })
 
-Then('the second holder waits for the key',
+Then('the second holder is refused',
   /**
    * @this {comq.features.Context}
    */
   async function () {
-    assert.equal(await until(() => this.locked === true), true, 'The second holder did not wait')
+    await assert.rejects(this.holding)
   })
 
 Then('the second holder holds the key',
@@ -228,6 +243,88 @@ Then('the second holder holds the key',
    */
   async function () {
     await this.holding
+  })
+
+Then('its recovery is refused while the broker holds the silent connection', { timeout: 60_000 },
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    const refused = await until(() => this.recoveries.some((error) => error.code === RESOURCE_LOCKED), 50_000)
+
+    const recorded = this.recoveries.map((error) => error.message).join('; ')
+
+    assert.equal(refused, true, `The recovery was not refused, recoveries failed with: [${recorded}]`)
+  })
+
+Then('a call to {token} under the {token} key is answered within {number} seconds', { timeout: 120_000 },
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, seconds) {
+    const answered = await eventually(() => this.io.call(exchange, key, { key }, { timeout: 1000 }), seconds)
+
+    assert.equal(answered, true, 'The call was not answered')
+  })
+
+Then('a call to {token} under the {token} key from another connection is answered within {number} seconds', { timeout: 120_000 },
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, seconds) {
+    const caller = await another(this)
+    const answered = await eventually(() => caller.call(exchange, key, { key }, { timeout: 1000 }), seconds)
+
+    assert.equal(answered, true, 'The call was not answered')
+  })
+
+Then('a call to {token} under the {token} key is refused within {number} seconds', { timeout: 60_000 },
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, seconds) {
+    const refused = await eventually(async () => {
+      try {
+        await this.io.call(exchange, key, { key }, { timeout: 1000 })
+      } catch (error) {
+        if (error instanceof Unroutable) return
+
+        throw error
+      }
+
+      throw new Error('Answered')
+    }, seconds)
+
+    assert.equal(refused, true, 'The call was not refused')
+  })
+
+Then('the call ends', { timeout: 90_000 },
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await this.reply.catch(() => undefined)
+  })
+
+Then('the consumer stops waiting within {number} second(s)', { timeout: 90_000 },
+  /**
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (seconds) {
+    const stopped = this.reply.then(() => 'answered', (error) => error.name === 'TimeoutError' ? 'stopped' : error.message)
+    const late = timeout(seconds * 1000).then(() => 'still waiting')
+
+    assert.equal(await Promise.race([stopped, late]), 'stopped')
   })
 
 Then('every call is answered',
@@ -267,7 +364,7 @@ After(
  * @param {number} [broker]
  * @returns {Promise<comq.IO>}
  */
-async function holder (context, broker) {
+async function another (context, broker) {
   const urls = broker !== undefined
     ? [url(broker)]
     : context.sharded ? [url(0), url(1)] : [url(0)]
@@ -298,6 +395,32 @@ function call (context, reply) {
 function url (broker) {
   return `amqp://${USER}:${PASSWORD}@${getAddress(broker)}`
 }
+
+/**
+ * Makes an attempt until it succeeds, or until the time is up.
+ *
+ * @param {() => Promise<unknown>} attempt
+ * @param {number} seconds
+ * @returns {Promise<boolean>} whether it succeeded
+ */
+async function eventually (attempt, seconds) {
+  const deadline = Date.now() + seconds * 1000
+
+  while (Date.now() < deadline) {
+    try {
+      await attempt()
+
+      return true
+    } catch {
+      await timeout(500)
+    }
+  }
+
+  return false
+}
+
+// the AMQP reply code a broker refuses a queue with when another connection holds it
+const RESOURCE_LOCKED = 405
 
 function echo (payload) {
   return payload

--- a/features/steps/call.js
+++ b/features/steps/call.js
@@ -20,6 +20,8 @@ Given('a holder answering {token} under the {token} key:',
     // eslint-disable-next-line no-new-func
     const producer = new Function('return ' + javascript)()
 
+    this.io.diagnose('taken', () => (this.taken = true))
+
     await this.io.back(exchange, key, producer)
   })
 
@@ -102,16 +104,6 @@ When('the silent holder crashes',
     connection.connection.stream.destroy()
   })
 
-Given('the connection\'s failed recoveries are recorded',
-  /**
-   * @this {comq.features.Context}
-   */
-  function () {
-    this.recoveries = []
-
-    this.io.diagnose('error', (error) => this.recoveries.push(error))
-  })
-
 When('the consumer calls {token} under the {token} key',
   /**
    * @param {string} exchange
@@ -184,6 +176,8 @@ When('a second holder on another connection holds {token} under the {token} key'
   async function (exchange, key) {
     const second = await another(this)
 
+    second.diagnose('taken', () => (this.taken = true))
+
     this.holding = second.back(exchange, key, echo)
 
     // asserted on by a later step, and an unhandled rejection would end the run before it
@@ -229,12 +223,60 @@ Then('the consumer stops waiting',
     await assert.rejects(this.reply, (error) => error.name === 'TimeoutError')
   })
 
-Then('the second holder is refused',
+Given('a holder connected to broker {number} answering {token} under the {token} key as {token}',
+  /**
+   * @param {number} broker
+   * @param {string} exchange
+   * @param {string} key
+   * @param {string} name
+   * @this {comq.features.Context}
+   */
+  async function (broker, exchange, key, name) {
+    this.holder = await another(this, broker)
+
+    await this.holder.back(exchange, key, () => name)
+  })
+
+When('a second holder on another connection holds {token} under the {token} key as {token}',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {string} name
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, name) {
+    const second = await another(this)
+
+    second.diagnose('taken', () => (this.taken = true))
+
+    await second.back(exchange, key, () => name)
+  })
+
+Then('the second holder finds the key taken',
   /**
    * @this {comq.features.Context}
    */
   async function () {
-    await assert.rejects(this.holding)
+    assert.equal(await until(() => this.taken === true), true, 'The key was not found taken')
+  })
+
+Then('every call to {token} under the {token} key is answered by {token} within {number} seconds', { timeout: 120_000 },
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {string} name
+   * @param {number} seconds
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, name, seconds) {
+    const answered = await eventually(async () => {
+      const calls = Array.from({ length: 20 }, () => this.io.call(exchange, key, null, { timeout: 1000 }))
+      const replies = await Promise.all(calls)
+
+      if (!replies.every((reply) => reply === name)) throw new Error('Answered by another')
+    }, seconds)
+
+    assert.equal(answered, true, `Calls were not all answered by ${name}`)
   })
 
 Then('the second holder holds the key',
@@ -245,16 +287,12 @@ Then('the second holder holds the key',
     await this.holding
   })
 
-Then('its recovery is refused while the broker holds the silent connection', { timeout: 60_000 },
+Then('the holder finds its key taken while the broker holds the silent connection', { timeout: 60_000 },
   /**
    * @this {comq.features.Context}
    */
   async function () {
-    const refused = await until(() => this.recoveries.some((error) => error.code === RESOURCE_LOCKED), 50_000)
-
-    const recorded = this.recoveries.map((error) => error.message).join('; ')
-
-    assert.equal(refused, true, `The recovery was not refused, recoveries failed with: [${recorded}]`)
+    assert.equal(await until(() => this.taken === true, 50_000), true, 'The key was not found taken')
   })
 
 Then('a call to {token} under the {token} key is answered within {number} seconds', { timeout: 120_000 },
@@ -418,9 +456,6 @@ async function eventually (attempt, seconds) {
 
   return false
 }
-
-// the AMQP reply code a broker refuses a queue with when another connection holds it
-const RESOURCE_LOCKED = 405
 
 function echo (payload) {
   return payload

--- a/features/steps/call.js
+++ b/features/steps/call.js
@@ -1,0 +1,304 @@
+'use strict'
+
+const assert = require('node:assert')
+const amqplib = require('amqplib')
+const { Given, When, Then, After } = require('@cucumber/cucumber')
+
+const { connect, Unroutable } = require('../../')
+const { parse } = require('./yaml')
+const { getAddress, USER, PASSWORD } = require('./brokers')
+const { timeout, until } = require('../../test/helpers')
+
+Given('a holder answering {token} under the {token} key:',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {string} javascript
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, javascript) {
+    // eslint-disable-next-line no-new-func
+    const producer = new Function('return ' + javascript)()
+
+    await this.io.back(exchange, key, producer)
+  })
+
+Given('a holder on another connection answering {token} under the {token} key',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key) {
+    this.holder = await holder(this)
+
+    await this.holder.back(exchange, key, echo)
+  })
+
+Given('a holder on another connection answering {token} under the {token} key in {number}ms',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {number} delay
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, delay) {
+    this.holder = await holder(this)
+
+    await this.holder.back(exchange, key, async (payload) => {
+      await timeout(delay)
+
+      return echo(payload)
+    })
+  })
+
+Given('a holder connected to broker {number} answering {token} under the {token} key',
+  /**
+   * @param {number} broker
+   * @param {string} exchange
+   * @param {string} key
+   * @this {comq.features.Context}
+   */
+  async function (broker, exchange, key) {
+    this.holder = await holder(this, broker)
+
+    await this.holder.back(exchange, key, echo)
+  })
+
+Given('a holder never answering {token} under the {token} key',
+  /**
+   * Holds the key as comq does, and takes a Request without ever answering it, so that losing
+   * its connection loses the Request with it.
+   *
+   * @param {string} exchange
+   * @param {string} key
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key) {
+    const connection = await amqplib.connect(url(0))
+    const channel = await connection.createChannel()
+    const queue = exchange + '.' + key
+
+    await channel.assertExchange(exchange, 'direct', { durable: true })
+    await channel.assertQueue(queue, { exclusive: true })
+    await channel.bindQueue(queue, exchange, key)
+    await channel.consume(queue, () => undefined)
+
+    this.silent = connection
+  })
+
+When('the silent holder\'s connection is lost',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await this.silent.close()
+
+    this.silent = undefined
+  })
+
+When('the consumer calls {token} under the {token} key',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key) {
+    call(this, this.io.call(exchange, key, { key }))
+  })
+
+When('the consumer calls {token} under the {token} key with:',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {string} yaml
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, yaml) {
+    call(this, this.io.call(exchange, key, parse(yaml)))
+  })
+
+When('the consumer calls {token} under the {token} key with a {number}ms timeout',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {number} ms
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, ms) {
+    call(this, this.io.call(exchange, key, { key }, { timeout: ms }))
+  })
+
+When('the consumer calls {token} under the {token} key {number} times',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @param {number} times
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key, times) {
+    const calls = Array.from({ length: times }, (_, n) => this.io.call(exchange, key, n))
+
+    this.replies = await Promise.all(calls)
+  })
+
+When('the consumer sends a request to the {token} queue with a {number}ms timeout',
+  /**
+   * @param {string} queue
+   * @param {number} ms
+   * @this {comq.features.Context}
+   */
+  async function (queue, ms) {
+    call(this, this.io.request(queue, { queue }, { timeout: ms }))
+  })
+
+When('the holder is sealed',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await this.holder.seal()
+  })
+
+When('a second holder on another connection holds {token} under the {token} key',
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   * @this {comq.features.Context}
+   */
+  async function (exchange, key) {
+    const second = await holder(this)
+
+    this.locked = false
+    second.diagnose('locked', () => (this.locked = true))
+
+    this.holding = second.back(exchange, key, echo)
+  })
+
+When('the first holder disconnects',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await this.holder.close()
+  })
+
+When('a producer counting requests to the {token} queue',
+  /**
+   * @param {string} queue
+   * @this {comq.features.Context}
+   */
+  async function (queue) {
+    this.produced = 0
+
+    await this.io.reply(queue, () => {
+      this.produced++
+
+      return null
+    })
+  })
+
+Then('the call is refused as unroutable',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await assert.rejects(this.reply, (error) => error instanceof Unroutable)
+  })
+
+Then('the consumer stops waiting',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await assert.rejects(this.reply, (error) => error.name === 'TimeoutError')
+  })
+
+Then('the second holder waits for the key',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    assert.equal(await until(() => this.locked === true), true, 'The second holder did not wait')
+  })
+
+Then('the second holder holds the key',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await this.holding
+  })
+
+Then('every call is answered',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    assert.deepEqual(this.replies, this.replies.map((_, n) => n))
+  })
+
+Then('the producer receives nothing',
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await timeout(500)
+
+    assert.equal(this.produced, 0, 'An expired request was processed')
+  })
+
+After(
+  /**
+   * @this {comq.features.Context}
+   */
+  async function () {
+    await Promise.all((this.holders ?? []).map((io) => io.close()))
+    await this.silent?.close().catch(() => undefined)
+
+    this.holders = []
+    this.silent = undefined
+  })
+
+/**
+ * Another connection, to the brokers the consumer is connected to, or to one of them.
+ *
+ * @param {comq.features.Context} context
+ * @param {number} [broker]
+ * @returns {Promise<comq.IO>}
+ */
+async function holder (context, broker) {
+  const urls = broker !== undefined
+    ? [url(broker)]
+    : context.sharded ? [url(0), url(1)] : [url(0)]
+
+  const io = await connect(...urls)
+
+  context.holders ??= []
+  context.holders.push(io)
+
+  return io
+}
+
+/**
+ * @param {comq.features.Context} context
+ * @param {Promise<any>} reply
+ */
+function call (context, reply) {
+  // asserted on by a later step, and an unhandled rejection would end the run before it
+  reply.catch(() => undefined)
+
+  context.reply = reply
+}
+
+/**
+ * @param {number} broker
+ * @returns {string}
+ */
+function url (broker) {
+  return `amqp://${USER}:${PASSWORD}@${getAddress(broker)}`
+}
+
+function echo (payload) {
+  return payload
+}

--- a/features/steps/network.js
+++ b/features/steps/network.js
@@ -26,6 +26,14 @@ When('the network goes silent',
     silence.call(this)
   })
 
+When('the silent connection is let go',
+  /**
+   * @this {comq.features.Context}
+   */
+  function () {
+    for (const network of this.networks) network.release()
+  })
+
 // a request that is answered over a connection that is already silent proves
 // nothing, hence the window between the two is left as short as a step boundary
 When('the consumer sends a request to the {token} queue as the network goes silent',

--- a/features/steps/networks.js
+++ b/features/steps/networks.js
@@ -51,6 +51,14 @@ class Network {
     for (const tunnel of this.#tunnels) tunnel.silent = true
   }
 
+  /**
+   * Closes the tunnels that went silent, at both ends, so the broker learns that the
+   * connection it was still holding is gone — the moment its heartbeat would otherwise tell it.
+   */
+  release () {
+    for (const tunnel of this.#tunnels) if (tunnel.silent) this.#collapse(tunnel)
+  }
+
   async close () {
     for (const tunnel of this.#tunnels) this.#collapse(tunnel)
 
@@ -71,10 +79,22 @@ class Network {
     client.on('data', (chunk) => { if (!tunnel.silent) upstream.write(chunk) })
     upstream.on('data', (chunk) => { if (!tunnel.silent) client.write(chunk) })
 
-    for (const socket of [client, upstream]) {
-      socket.on('error', () => this.#collapse(tunnel))
-      socket.on('close', () => this.#collapse(tunnel))
-    }
+    // a silent network tells neither end that the other has gone: the client giving up on a
+    // silent connection leaves the broker holding its end, until the network is let go
+    client.on('error', () => this.#hangUp(tunnel))
+    client.on('close', () => this.#hangUp(tunnel))
+
+    upstream.on('error', () => this.#collapse(tunnel))
+    upstream.on('close', () => this.#collapse(tunnel))
+  }
+
+  /**
+   * @param {comq.features.Tunnel} tunnel
+   */
+  #hangUp (tunnel) {
+    if (!tunnel.silent) return this.#collapse(tunnel)
+
+    tunnel.client.destroy()
   }
 
   /**

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ for distributed, eventually consistent systems running on Node.js.
 
 - [Dynamic topology](#topology)
 - [Request](#request)-[reply](#reply) (RPC), with a [timeout](#timeout)
-- [Calls](#call-and-back) to the one connection holding a key
+- [Addressed requests](#addressed-requests) to the one connection holding a Key
 - Events ([pub](#emission)/[sub](#consumption)), fanned out or [routed](#routing)
 - [Tasks](#tasks)
 - [Pipelines](#pipelines)
@@ -226,7 +226,7 @@ await io.route('records', 'store.orders', { id: 1, status: 'paid' })
 await io.route('records', 'store.customers', { id: 2 }) // not delivered to the above
 ```
 
-## Call and back
+## Addressed Requests
 
 `async IO.back(exchange: string, key: string, producer): void`
 
@@ -540,7 +540,7 @@ requests and are expecting replies.
   and [Consumption](#consumption), and as _direct_ for [Routing](#routing). One name is one or
   the other: asserting it as both is what the broker refuses.
 - Queues for Replies are _exclusive_ and _auto deleted_.
-- A queue [`back`](#call-and-back) holds is _exclusive_, bound under its Key to a _direct_
+- A queue [`back`](#addressed-requests) holds is _exclusive_, bound under its Key to a _direct_
   exchange.
 
 comq declares two kinds of queue of its own, for [failed messages](#retries):
@@ -720,7 +720,7 @@ Event *are*.
 Requests.
 Sending Requests, receiving Replies, and emitting Events will still be available.
 
-Keys held by [`back`](#call-and-back) are withdrawn first, so a call published from then on is
+Keys held by [`back`](#addressed-requests) are withdrawn first, so a call published from then on is
 refused.
 
 ### Disconnection
@@ -793,7 +793,7 @@ Subscribe to one of the diagnostic events:
   [amqp message object](https://amqp-node.github.io/amqplib/channel_api.html#channel_publish) are
   passed as arguments. In the case of a [sharded connection](#sharded-connection), the message is
   reported only once every shard has rejected it.
-- `taken`: a Key [`back`](#call-and-back) claims is held by another connection on this broker, and
+- `taken`: a Key [`back`](#addressed-requests) claims is held by another connection on this broker, and
   is claimed again. Channel type and the queue name are passed.
 - `pause`: channel is paused. Channel type is passed.
   In the case of a [sharded connection](#sharded-connection), it means that there is no shard left

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,8 @@ for distributed, eventually consistent systems running on Node.js.
 ## Features
 
 - [Dynamic topology](#topology)
-- [Request](#request)-[reply](#reply) (RPC)
+- [Request](#request)-[reply](#reply) (RPC), with a [timeout](#timeout)
+- [Calls](#call-and-back) to the one connection holding a key
 - Events ([pub](#emission)/[sub](#consumption)), fanned out or [routed](#routing)
 - [Tasks](#tasks)
 - [Pipelines](#pipelines)
@@ -106,17 +107,46 @@ await io.reply('add_numbers', ({ a, b }) => (a + b))
 
 ## Request
 
-`async IO.request(queue: string, payload: any, encoding?: string): any`
+`async IO.request(queue: string, payload: any, options?: string | RequestOptions): any`
 
 Send encoded Request message with `replyTo` and `correlationId` properties set and
-return decoded Reply content. The promise stays pending until the Reply arrives.
+return decoded Reply content. The promise stays pending until the Reply arrives, or until the
+[timeout](#timeout) passes.
 
 On the initial call, queues for Requests and Replies are asserted.
+
+`options` is the encoding, or an object:
+
+| Option     | Type          | Default            |
+|------------|---------------|--------------------|
+| `encoding` | `string`      | `application/json` |
+| `timeout`  | `number`, ms  | none               |
+| `signal`   | `AbortSignal` | none               |
 
 ### Example
 
 ```javascript
 const sum = await io.request('add_numbers', { a: 1, b: 2 })
+```
+
+### Timeout
+
+A Request with a `timeout` rejects once it passes, with the `TimeoutError` of
+[`AbortSignal.timeout`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static).
+It is published with that much
+[expiration](https://www.rabbitmq.com/docs/ttl#per-message-ttl-in-publishers), so a Request no
+Producer has taken by then is dropped by the broker and never processed. A Request a Producer has
+already taken is processed to the end, and its Reply is discarded. A Request re-sent after a lost
+connection carries the time it has left.
+
+A `signal` rejects the Request with its reason once aborted, within the `timeout` where both are
+given. A Request with a `signal` alone stays in its queue.
+
+A Request that failed and waits for its [next attempt](#retries) loses its expiration on the way
+back to its queue, so it may be processed after its caller has stopped waiting.
+
+```javascript
+const sum = await io.request('add_numbers', { a: 1, b: 2 }, { timeout: 5000 })
 ```
 
 ## Consumption
@@ -192,6 +222,59 @@ await io.subscribe('records', 'records.orders', 'store.orders',
 
 await io.route('records', 'store.orders', { id: 1, status: 'paid' })
 await io.route('records', 'store.customers', { id: 2 }) // not delivered to the above
+```
+
+## Call and back
+
+`async IO.back(exchange: string, key: string, producer): void`
+
+`async IO.call(exchange: string, key: string, payload: any, options?: string | RequestOptions): any`
+
+A Request to the one connection holding a Key, where a [Request](#request) goes to whichever
+Producer takes it first.
+
+`back` asserts a [direct exchange](#routing) and a queue named `<exchange>.<key>`, *exclusive* to
+the connection, binds it under the `key` and starts consuming Requests, as [`reply`](#reply) does.
+**Only one connection holds a Key at a time.** While another connection holds it, `back` waits
+for it to be let go, and emits [`locked`](#diagnostics) each time it finds the Key held. The Key
+is let go when its connection closes, however it closes.
+
+`call` publishes the encoded Request to the exchange under the `key` and returns the decoded Reply,
+taking the same options as [`request`](#request).
+
+A call ends in one of three ways:
+
+- **A Reply.**
+- **Refused at once**, rejecting with `Unroutable`, when no connection holds the Key: it never did,
+  its holder has closed, or its holder is [sealed](#sealing). A refused call reached no one.
+- **At its [timeout](#timeout)**, when its holder has gone without being sealed — a crashed process,
+  a lost connection — or takes longer. A call nobody has taken by then is dropped.
+
+A call waits for as long as it takes unless it has a timeout, and a holder that is gone never
+answers it. **Give every call a timeout.**
+
+Sealing withdraws every Key before it stops consuming: a call published from then on is refused,
+and one published before it is delivered and answered. Calls queued beyond the
+[prefetch](#channels) at that moment go with the connection and end at their timeout.
+
+A Key is as alive as its connection: while the holder reconnects, calls to it are refused, and
+calls queued for it are lost.
+
+Over a [sharded connection](#sharded-connection), `back` holds the Key on every shard, and a call
+returned by one shard is published on the next, refused once every shard has returned it.
+
+### Example
+
+```javascript
+const { Unroutable } = require('comq')
+
+await io.back('sessions', 'a1', (message) => sessions.get(message.id))
+
+try {
+  const session = await io.call('sessions', 'a1', { id: 7 }, { timeout: 5000 })
+} catch (error) {
+  if (error instanceof Unroutable) console.log('Nobody holds', error.key)
+}
 ```
 
 ## Tasks
@@ -449,6 +532,8 @@ requests and are expecting replies.
   and [Consumption](#consumption), and as _direct_ for [Routing](#routing). One name is one or
   the other: asserting it as both is what the broker refuses.
 - Queues for Replies are _exclusive_ and _auto deleted_.
+- A queue [`back`](#call-and-back) holds is _exclusive_, bound under its Key to a _direct_
+  exchange.
 
 comq declares two kinds of queue of its own, for [failed messages](#retries):
 
@@ -490,8 +575,8 @@ other consumers nor that consumer's next message; only the message that failed i
 | Event | 1s, 10s, 30s, 90s | 5 | 131s |
 | Request | 1s, 3s, 5s, 10s | 5 | 19s |
 
-Requests are shorter because a caller is blocked on one with no timeout, and a Reply arriving
-long after it gave up has nowhere useful to land. Nobody waits on an Event.
+Requests are shorter because a caller is blocked on one, and a Reply arriving long after it
+stopped waiting has nowhere useful to land. Nobody waits on an Event.
 
 One retry queue and one exchange are declared per distinct wait and shared by every queue that
 uses them, so their number grows with the length of the ladder rather than with the number of
@@ -548,8 +633,9 @@ Parked queues grow until somebody drains them, which is deliberate — the alter
 evidence. Alert on [`discard`](#diagnostics), and do not delete `comq.retry.*` or `comq.parked.*`
 queues on a running system.
 
-> **A parked Request is never answered.** A Consumer awaiting its Reply waits indefinitely, and
-> with a limited prefetch that can deadlock it. Parking keeps the Request rather than deleting
+> **A parked Request is never answered.** A Consumer awaiting its Reply waits until its
+> [timeout](#timeout), or indefinitely without one, and with a limited prefetch that can deadlock
+> it. Parking keeps the Request rather than deleting
 > it — and it keeps `replyTo` and `correlationId`, so a Reply can still be produced from it by
 > hand while the caller is alive — but comq itself sends no Reply and reports no error to the
 > caller.
@@ -626,6 +712,9 @@ Event *are*.
 Requests.
 Sending Requests, receiving Replies, and emitting Events will still be available.
 
+Keys held by [`back`](#call-and-back) are withdrawn first, so a call published from then on is
+refused.
+
 ### Disconnection
 
 `async IO.close(): void`
@@ -696,6 +785,8 @@ Subscribe to one of the diagnostic events:
   [amqp message object](https://amqp-node.github.io/amqplib/channel_api.html#channel_publish) are
   passed as arguments. In the case of a [sharded connection](#sharded-connection), the message is
   reported only once every shard has rejected it.
+- `locked`: the queue of a Key [`back`](#call-and-back) asks for is held by another connection,
+  and will be asked for again. Channel type and the queue name are passed.
 - `pause`: channel is paused. Channel type is passed.
   In the case of a [sharded connection](#sharded-connection), it means that there is no shard left
   to publish to, be it because every one of them has rejected a publish or lost its connection.

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,9 @@ already taken is processed to the end, and its Reply is discarded. A Request re-
 connection carries the time it has left.
 
 A `signal` rejects the Request with its reason once aborted, within the `timeout` where both are
-given. A Request with a `signal` alone stays in its queue.
+given. It ends the wait and leaves the Request where it is: in its queue until the `timeout`
+passes, or, without a `timeout`, until a Producer takes it. A Request abandoned by its `signal` may
+therefore still be processed.
 
 A Request that failed and waits for its [next attempt](#retries) loses its expiration on the way
 back to its queue, so it may be processed after its caller has stopped waiting.
@@ -235,9 +237,11 @@ Producer takes it first.
 
 `back` asserts a [direct exchange](#routing) and a queue named `<exchange>.<key>`, *exclusive* to
 the connection, binds it under the `key` and starts consuming Requests, as [`reply`](#reply) does.
-**Only one connection holds a Key at a time.** While another connection holds it, `back` waits
-for it to be let go, and emits [`locked`](#diagnostics) each time it finds the Key held. The Key
-is let go when its connection closes, however it closes.
+**Only one connection holds a Key at a time.** While another connection holds it, `back` rejects.
+The Key is let go when its connection closes, however it closes — once the broker has noticed, for
+a connection that went without a word. A connection that is [restored](#connection-tolerance)
+holds its Keys again as part of its recovery, and a recovery that finds one held fails and is made
+again.
 
 `call` publishes the encoded Request to the exchange under the `key` and returns the decoded Reply,
 taking the same options as [`request`](#request).
@@ -785,8 +789,6 @@ Subscribe to one of the diagnostic events:
   [amqp message object](https://amqp-node.github.io/amqplib/channel_api.html#channel_publish) are
   passed as arguments. In the case of a [sharded connection](#sharded-connection), the message is
   reported only once every shard has rejected it.
-- `locked`: the queue of a Key [`back`](#call-and-back) asks for is held by another connection,
-  and will be asked for again. Channel type and the queue name are passed.
 - `pause`: channel is paused. Channel type is passed.
   In the case of a [sharded connection](#sharded-connection), it means that there is no shard left
   to publish to, be it because every one of them has rejected a publish or lost its connection.

--- a/readme.md
+++ b/readme.md
@@ -237,11 +237,12 @@ Producer takes it first.
 
 `back` asserts a [direct exchange](#routing) and a queue named `<exchange>.<key>`, *exclusive* to
 the connection, binds it under the `key` and starts consuming Requests, as [`reply`](#reply) does.
-**Only one connection holds a Key at a time.** While another connection holds it, `back` rejects.
-The Key is let go when its connection closes, however it closes — once the broker has noticed, for
-a connection that went without a word. A connection that is [restored](#connection-tolerance)
-holds its Keys again as part of its recovery, and a recovery that finds one held fails and is made
-again.
+**On each broker, one connection holds a Key at a time.** While another connection holds it,
+`back` claims it again and again, with the backoff a lost connection is
+[restored](#connection-tolerance) with, and emits [`taken`](#diagnostics) on every refusal. The Key
+is let go when its connection closes, however it closes — once the broker has noticed, for a
+connection that went without a word. `back` returns once a broker holds the Key. The rest of the
+connection works throughout, and a connection that is restored claims its Keys again the same way.
 
 `call` publishes the encoded Request to the exchange under the `key` and returns the decoded Reply,
 taking the same options as [`request`](#request).
@@ -264,8 +265,11 @@ and one published before it is delivered and answered. Calls queued beyond the
 A Key is as alive as its connection: while the holder reconnects, calls to it are refused, and
 calls queued for it are lost.
 
-Over a [sharded connection](#sharded-connection), `back` holds the Key on every shard, and a call
-returned by one shard is published on the next, refused once every shard has returned it.
+Over a [sharded connection](#sharded-connection), `back` claims the Key on every shard and returns
+once one of them holds it; a shard where it is taken goes on claiming it. Two connections given the
+same Key can therefore hold it on different shards and both answer calls, and `taken` is what says
+so. A call returned by one shard is published on the next, and refused once every shard has
+returned it.
 
 ### Example
 
@@ -789,6 +793,8 @@ Subscribe to one of the diagnostic events:
   [amqp message object](https://amqp-node.github.io/amqplib/channel_api.html#channel_publish) are
   passed as arguments. In the case of a [sharded connection](#sharded-connection), the message is
   reported only once every shard has rejected it.
+- `taken`: a Key [`back`](#call-and-back) claims is held by another connection on this broker, and
+  is claimed again. Channel type and the queue name are passed.
 - `pause`: channel is paused. Channel type is passed.
   In the case of a [sharded connection](#sharded-connection), it means that there is no shard left
   to publish to, be it because every one of them has rejected a publish or lost its connection.

--- a/source/attributes/recall.js
+++ b/source/attributes/recall.js
@@ -15,7 +15,8 @@ const recorder = (context, method) => async function (...args) {
 
   const result = await method.apply(context, args)
 
-  method[CALLS].push(args)
+  // forgotten while it ran, by a seal: a sealed context replays nothing
+  method[CALLS]?.push(args)
 
   return result
 }

--- a/source/channel.js
+++ b/source/channel.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { setTimeout: wait } = require('node:timers/promises')
 const { Promex } = require('promex')
 const { failsafe, lazy, recall } = require('./attributes')
 const { verdictOf, PARK } = require('./verdicts')
@@ -143,7 +142,8 @@ class Channel {
   /**
    * Consumes a queue exclusive to this connection, bound to a direct exchange under a key:
    * whatever is published under that key reaches this connection and no other. While another
-   * connection holds the queue, this waits for it to be let go.
+   * connection holds the queue, this rejects, and so does a recovery that replays it: the
+   * connection is then reopened and recovered again, as after any failed recovery.
    */
   held = recall(this,
     failsafe(this, this.#recover,
@@ -156,14 +156,7 @@ class Channel {
          * @returns {Promise<void>}
          */
         async (exchange, queue, key, callback) => {
-          if (this.#sealed) return
-
-          const holding = this.#hold(exchange, queue, key, callback)
-
-          // a recovery replays every call at once, and one waiting for another connection
-          // to let go of its queue must leave the others to be restored
-          if (this.#recovering) holding.catch(noop)
-          else await holding
+          if (!this.#sealed) await this.#hold(exchange, queue, key, callback)
         })))
 
   send = failsafe(this, this.#recover,
@@ -301,10 +294,7 @@ class Channel {
    * @returns {Promise<void>}
    */
   async #hold (exchange, queue, key, callback) {
-    const held = await this.#lock(queue)
-
-    if (!held) return
-
+    await this.#claim(queue)
     await this.#assertQueue(queue, EXCLUSIVE)
     await this.#channel.bindQueue(queue, exchange, key)
 
@@ -314,45 +304,33 @@ class Channel {
   }
 
   /**
-   * Declares a queue exclusive to this connection, and waits while another connection holds it.
+   * Declares a queue exclusive to this connection.
    *
-   * The broker refuses such a queue by closing the channel that asked for it, so the
-   * declaration is made on a channel of its own, which is all that goes down with it. The queue
-   * belongs to the connection rather than to that channel, and outlives it. The broker announces
-   * nothing when a queue is let go, so it is asked again.
+   * The broker refuses a queue another connection holds by closing the channel that asked for
+   * it, and a channel error nobody listens for closes the whole connection. So the declaration
+   * is made on a channel of its own, which is all that closes, and what the broker refused with
+   * is thrown. The queue belongs to the connection, and outlives that channel.
    *
    * @param {string} queue
-   * @returns {Promise<boolean>} whether the queue is held, as opposed to sealed while waiting
+   * @returns {Promise<void>}
    */
-  async #lock (queue) {
-    const connection = this.#connection
+  async #claim (queue) {
+    // a connection that is gone is recovered from, like any other interruption
+    const probe = await this.#connection.createChannel().catch(() => { throw INTERRUPTION })
 
-    while (true) {
-      /** @type {Error & { code?: number } | undefined} */
-      let refusal
+    /** @type {Error | undefined} */
+    let refusal
 
-      // a connection that is gone is recovered from, like any other interruption
-      const probe = await connection.createChannel().catch(() => { throw INTERRUPTION })
+    probe.on('error', (error) => { refusal = error })
 
-      probe.on('error', (error) => { refusal = error })
-
-      try {
-        await probe.assertQueue(queue, EXCLUSIVE)
-        await probe.close().catch(noop)
-
-        return true
-      } catch (exception) {
-        // what the broker refused with says more than the channel it closed
-        if (refusal?.code !== RESOURCE_LOCKED) throw refusal ?? exception
-      }
-
-      this.#diagnostics.emit('locked', queue)
-
-      await wait(global.COMQ_TESTING_LOCK_INTERVAL ?? LOCK_INTERVAL)
-
-      if (this.#sealed) return false
-      if (connection !== this.#connection) throw INTERRUPTION
+    try {
+      await probe.assertQueue(queue, EXCLUSIVE)
+    } catch (exception) {
+      // what the broker refused with says more than the channel it closed
+      throw refusal ?? exception
     }
+
+    await probe.close().catch(noop)
   }
 
   // region initializers
@@ -753,12 +731,6 @@ const DURABLE = { durable: true }
 const EXCLUSIVE = { exclusive: true }
 
 const INTERRUPTION = /** @type {Error} */ Symbol('internal interruption')
-
-// the AMQP reply code a broker closes a channel with when another connection holds the queue
-const RESOURCE_LOCKED = 405
-
-// how often a queue another connection holds is asked for again
-const LOCK_INTERVAL = 1000
 
 const RETRY_PREFIX = 'comq.retry.'
 const PARKED_PREFIX = 'comq.parked.'

--- a/source/channel.js
+++ b/source/channel.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Promex } = require('promex')
+const { retry } = require('reretry')
 const { failsafe, lazy, recall } = require('./attributes')
 const { verdictOf, PARK } = require('./verdicts')
 const emitter = require('./emitter')
@@ -142,8 +143,8 @@ class Channel {
   /**
    * Consumes a queue exclusive to this connection, bound to a direct exchange under a key:
    * whatever is published under that key reaches this connection and no other. While another
-   * connection holds the queue, this rejects, and so does a recovery that replays it: the
-   * connection is then reopened and recovered again, as after any failed recovery.
+   * connection holds the queue, it is claimed again and again until it is let go, and every
+   * refusal is reported as `taken`.
    */
   held = recall(this,
     failsafe(this, this.#recover,
@@ -156,7 +157,14 @@ class Channel {
          * @returns {Promise<void>}
          */
         async (exchange, queue, key, callback) => {
-          if (!this.#sealed) await this.#hold(exchange, queue, key, callback)
+          if (this.#sealed) return
+
+          const holding = this.#hold(exchange, queue, key, callback)
+
+          // a recovery restores the rest of the connection while a key another connection holds
+          // is claimed, and a claim the connection is lost under is replayed by the next recovery
+          if (this.#recovering) holding.catch(noop)
+          else await holding
         })))
 
   send = failsafe(this, this.#recover,
@@ -294,7 +302,10 @@ class Channel {
    * @returns {Promise<void>}
    */
   async #hold (exchange, queue, key, callback) {
-    await this.#claim(queue)
+    const claimed = await this.#claim(queue)
+
+    if (!claimed) return
+
     await this.#assertQueue(queue, EXCLUSIVE)
     await this.#channel.bindQueue(queue, exchange, key)
 
@@ -304,21 +315,45 @@ class Channel {
   }
 
   /**
-   * Declares a queue exclusive to this connection.
-   *
-   * The broker refuses a queue another connection holds by closing the channel that asked for
-   * it, and a channel error nobody listens for closes the whole connection. So the declaration
-   * is made on a channel of its own, which is all that closes, and what the broker refused with
-   * is thrown. The queue belongs to the connection, and outlives that channel.
+   * Claims a queue exclusive to this connection, again and again while another connection
+   * holds it. The broker announces nothing when a queue is let go, so it is asked again, with
+   * the backoff a lost connection is restored with.
    *
    * @param {string} queue
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} whether the queue is claimed, as opposed to sealed while claiming
    */
   async #claim (queue) {
-    // a connection that is gone is recovered from, like any other interruption
-    const probe = await this.#connection.createChannel().catch(() => { throw INTERRUPTION })
+    const connection = this.#connection
 
-    /** @type {Error | undefined} */
+    return await retry(async (again) => {
+      if (this.#sealed) return false
+
+      // a connection that is gone is recovered from, like any other interruption
+      if (connection !== this.#connection) throw INTERRUPTION
+
+      if (await this.#declare(connection, queue)) return true
+
+      this.#diagnostics.emit('taken', queue)
+
+      return again
+    }, global.COMQ_TESTING_CLAIM_BACKOFF)
+  }
+
+  /**
+   * Declares a queue exclusive to this connection, and says whether another connection holds it.
+   *
+   * The broker refuses such a queue by closing the channel that asked for it, and a channel error
+   * nobody listens for closes the whole connection. So the declaration is made on a channel of its
+   * own, which is all that closes. The queue belongs to the connection, and outlives that channel.
+   *
+   * @param {comq.amqp.Connection} connection
+   * @param {string} queue
+   * @returns {Promise<boolean>}
+   */
+  async #declare (connection, queue) {
+    const probe = await connection.createChannel().catch(() => { throw INTERRUPTION })
+
+    /** @type {Error & { code?: number } | undefined} */
     let refusal
 
     probe.on('error', (error) => { refusal = error })
@@ -326,11 +361,15 @@ class Channel {
     try {
       await probe.assertQueue(queue, EXCLUSIVE)
     } catch (exception) {
+      if (refusal?.code === RESOURCE_LOCKED) return false
+
       // what the broker refused with says more than the channel it closed
       throw refusal ?? exception
     }
 
     await probe.close().catch(noop)
+
+    return true
   }
 
   // region initializers
@@ -731,6 +770,9 @@ const DURABLE = { durable: true }
 const EXCLUSIVE = { exclusive: true }
 
 const INTERRUPTION = /** @type {Error} */ Symbol('internal interruption')
+
+// the AMQP reply code a broker closes a channel with when another connection holds the queue
+const RESOURCE_LOCKED = 405
 
 const RETRY_PREFIX = 'comq.retry.'
 const PARKED_PREFIX = 'comq.parked.'

--- a/source/channel.js
+++ b/source/channel.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { setTimeout: wait } = require('node:timers/promises')
 const { Promex } = require('promex')
 const { failsafe, lazy, recall } = require('./attributes')
 const { verdictOf, PARK } = require('./verdicts')
@@ -33,6 +34,13 @@ class Channel {
    * @type {Map<string, comq.amqp.options.Queue>}
    */
   #queues = new Map()
+
+  /**
+   * The exchange and key each held queue is bound under, so that sealing withdraws them.
+   *
+   * @type {Map<string, [string, string]>}
+   */
+  #held = new Map()
 
   /** @type {Promex | null} */
   #paused = null
@@ -80,8 +88,9 @@ class Channel {
     // the consumers of the previous channel went down with it, their tags mean nothing here
     this.#tags = []
 
-    // a fresh channel has declared nothing
+    // a fresh channel has declared nothing, and bound nothing
     this.#queues.clear()
+    this.#held.clear()
 
     await this.#channel.prefetch(this.#topology.prefetch)
 
@@ -129,6 +138,32 @@ class Channel {
          */
         async (exchange, queue, key, callback) => {
           if (!this.#sealed) await this.#consume(queue, callback)
+        })))
+
+  /**
+   * Consumes a queue exclusive to this connection, bound to a direct exchange under a key:
+   * whatever is published under that key reaches this connection and no other. While another
+   * connection holds the queue, this waits for it to be let go.
+   */
+  held = recall(this,
+    failsafe(this, this.#recover,
+      lazy(this, this.#assertRouted,
+        /**
+         * @param {string} exchange
+         * @param {string} queue
+         * @param {string} key
+         * @param {comq.channels.Consumer} callback
+         * @returns {Promise<void>}
+         */
+        async (exchange, queue, key, callback) => {
+          if (this.#sealed) return
+
+          const holding = this.#hold(exchange, queue, key, callback)
+
+          // a recovery replays every call at once, and one waiting for another connection
+          // to let go of its queue must leave the others to be restored
+          if (this.#recovering) holding.catch(noop)
+          else await holding
         })))
 
   send = failsafe(this, this.#recover,
@@ -201,6 +236,15 @@ class Channel {
   async seal () {
     this.#sealed = true
 
+    // a key is withdrawn before its consumer goes: a Request published from here on is
+    // returned to its caller, and one published before it is delivered and answered
+    const unbindings = Array.from(this.#held,
+      ([queue, [exchange, key]]) => this.#channel.unbindQueue(queue, exchange, key))
+
+    await Promise.allSettled(unbindings)
+
+    this.#held.clear()
+
     const cancellations = this.#tags.map((tag) => this.#channel.cancel(tag))
 
     await Promise.all(cancellations).catch(noop) // won't recover anyway
@@ -247,6 +291,68 @@ class Channel {
     this.#recovery.resolve()
     this.#recovery = new Promex()
     this.#diagnostics.emit('recover')
+  }
+
+  /**
+   * @param {string} exchange
+   * @param {string} queue
+   * @param {string} key
+   * @param {comq.channels.Consumer} callback
+   * @returns {Promise<void>}
+   */
+  async #hold (exchange, queue, key, callback) {
+    const held = await this.#lock(queue)
+
+    if (!held) return
+
+    await this.#assertQueue(queue, EXCLUSIVE)
+    await this.#channel.bindQueue(queue, exchange, key)
+
+    this.#held.set(queue, [exchange, key])
+
+    if (!this.#sealed) await this.#consume(queue, callback)
+  }
+
+  /**
+   * Declares a queue exclusive to this connection, and waits while another connection holds it.
+   *
+   * The broker refuses such a queue by closing the channel that asked for it, so the
+   * declaration is made on a channel of its own, which is all that goes down with it. The queue
+   * belongs to the connection rather than to that channel, and outlives it. The broker announces
+   * nothing when a queue is let go, so it is asked again.
+   *
+   * @param {string} queue
+   * @returns {Promise<boolean>} whether the queue is held, as opposed to sealed while waiting
+   */
+  async #lock (queue) {
+    const connection = this.#connection
+
+    while (true) {
+      /** @type {Error & { code?: number } | undefined} */
+      let refusal
+
+      // a connection that is gone is recovered from, like any other interruption
+      const probe = await connection.createChannel().catch(() => { throw INTERRUPTION })
+
+      probe.on('error', (error) => { refusal = error })
+
+      try {
+        await probe.assertQueue(queue, EXCLUSIVE)
+        await probe.close().catch(noop)
+
+        return true
+      } catch (exception) {
+        // what the broker refused with says more than the channel it closed
+        if (refusal?.code !== RESOURCE_LOCKED) throw refusal ?? exception
+      }
+
+      this.#diagnostics.emit('locked', queue)
+
+      await wait(global.COMQ_TESTING_LOCK_INTERVAL ?? LOCK_INTERVAL)
+
+      if (this.#sealed) return false
+      if (connection !== this.#connection) throw INTERRUPTION
+    }
   }
 
   // region initializers
@@ -648,6 +754,12 @@ const EXCLUSIVE = { exclusive: true }
 
 const INTERRUPTION = /** @type {Error} */ Symbol('internal interruption')
 
+// the AMQP reply code a broker closes a channel with when another connection holds the queue
+const RESOURCE_LOCKED = 405
+
+// how often a queue another connection holds is asked for again
+const LOCK_INTERVAL = 1000
+
 const RETRY_PREFIX = 'comq.retry.'
 const PARKED_PREFIX = 'comq.parked.'
 
@@ -672,3 +784,4 @@ const PARKED_AT_HEADER = 'x-comq-at'
 function noop () {}
 
 exports.create = create
+exports.RETRY_PREFIX = RETRY_PREFIX

--- a/source/events.js
+++ b/source/events.js
@@ -4,4 +4,4 @@
 exports.connection = ['open', 'close', 'error', 'reconnect', 'exhausted']
 
 /** @type {comq.diagnostics.Event[]} */
-exports.channel = ['flow', 'drain', 'recover', 'discard', 'retry', 'pause', 'resume', 'return', 'lost', 'remove']
+exports.channel = ['flow', 'drain', 'recover', 'discard', 'retry', 'pause', 'resume', 'return', 'lost', 'remove', 'locked']

--- a/source/events.js
+++ b/source/events.js
@@ -4,4 +4,4 @@
 exports.connection = ['open', 'close', 'error', 'reconnect', 'exhausted']
 
 /** @type {comq.diagnostics.Event[]} */
-exports.channel = ['flow', 'drain', 'recover', 'discard', 'retry', 'pause', 'resume', 'return', 'lost', 'remove']
+exports.channel = ['flow', 'drain', 'recover', 'discard', 'retry', 'pause', 'resume', 'return', 'lost', 'remove', 'taken']

--- a/source/events.js
+++ b/source/events.js
@@ -4,4 +4,4 @@
 exports.connection = ['open', 'close', 'error', 'reconnect', 'exhausted']
 
 /** @type {comq.diagnostics.Event[]} */
-exports.channel = ['flow', 'drain', 'recover', 'discard', 'retry', 'pause', 'resume', 'return', 'lost', 'remove', 'locked']
+exports.channel = ['flow', 'drain', 'recover', 'discard', 'retry', 'pause', 'resume', 'return', 'lost', 'remove']

--- a/source/index.js
+++ b/source/index.js
@@ -2,9 +2,11 @@
 
 const { connect, assert } = require('./connect')
 const { Retry, Park } = require('./verdicts')
+const { Unroutable } = require('./unroutable')
 
 exports.connect = connect
 exports.assert = assert
 
 exports.Retry = Retry
 exports.Park = Park
+exports.Unroutable = Unroutable

--- a/source/io.js
+++ b/source/io.js
@@ -5,6 +5,7 @@ const { setTimeout } = require('node:timers/promises')
 const { Promex } = require('promex')
 const { memo, failsafe, lazy, track } = require('./attributes')
 const { verdictOf, PARK } = require('./verdicts')
+const { Unroutable } = require('./unroutable')
 
 const { decode } = require('./decode')
 const { encode } = require('./encode')
@@ -75,31 +76,83 @@ class IO {
       await this.#requests.consume(queue, consumer)
     })
 
-  // failsafe is aimed to retransmit unanswered messages
-  request = lazy(this, [this.#createRequestReplyChannels, this.#consumeReplies],
+  /**
+   * @param {string} queue
+   * @param {any | Readable} payload
+   * @param {comq.Encoding | comq.RequestOptions} [options]
+   * @returns {Promise<any | Readable>}
+   */
+  request (queue, payload, options) {
+    return this.#request(queue, payload, terms(options))
+  }
+
+  /**
+   * A Request to whoever holds `key` on a routed `exchange`, through `back`. One nobody holds
+   * is returned by the broker and rejects with `Unroutable`.
+   *
+   * @param {string} exchange
+   * @param {string} key
+   * @param {any} payload
+   * @param {comq.Encoding | comq.RequestOptions} [options]
+   * @returns {Promise<any | Readable>}
+   */
+  call (exchange, key, payload, options) {
+    return this.#call(exchange, key, payload, terms(options))
+  }
+
+  /**
+   * Answers the Requests `call` makes under `key`, from a queue that belongs to this
+   * connection alone. Sealing withdraws the key before it stops consuming.
+   */
+  back = lazy(this, this.#createRequestReplyChannels,
+    /**
+     * @param {string} exchange
+     * @param {string} key
+     * @param {comq.Producer} callback
+     * @returns {Promise<void>}
+     */
+    async (exchange, key, callback) => {
+      const consumer = this.#getRequestConsumer(callback)
+
+      await this.#requests.held(exchange, exchange + '.' + key, key, consumer)
+    })
+
+  // failsafe is aimed to retransmit unanswered messages; the terms are taken once, so a
+  // re-sent Request keeps the deadline of the first
+  #request = lazy(this, [this.#createRequestReplyChannels, this.#consumeReplies],
     failsafe(this, this.#recover,
       /**
        * @param {string} queue
        * @param {any | Readable} payload
-       * @param {comq.Encoding} [encoding]
+       * @param {comq.Terms} terms
        * @returns {Promise<any | Readable>}
        */
-      async (queue, payload, encoding) => {
+      async (queue, payload, terms) => {
         if (payload instanceof stream.Readable) {
           return pipeline(
             payload,
-            (payload) => this.request(queue, payload, encoding),
+            (payload) => this.#request(queue, payload, terms),
             this.#requests
           )
         }
 
-        const [buffer, contentType] = this.#encode(payload, encoding)
-        const request = this.#createRequest(queue, contentType)
-        const reply = this.#createReply(request)
+        return await this.#ask(queue, payload, terms,
+          (buffer, properties) => this.#requests.send(queue, buffer, properties))
+      }))
 
-        await this.#requests.send(queue, buffer, request.properties)
-
-        return reply
+  #call = lazy(this, [this.#createRequestReplyChannels, this.#consumeReplies],
+    failsafe(this, this.#recover,
+      /**
+       * @param {string} exchange
+       * @param {string} key
+       * @param {any} payload
+       * @param {comq.Terms} terms
+       * @returns {Promise<any | Readable>}
+       */
+      async (exchange, key, payload, terms) => {
+        // mandatory: a Request nobody holds the key of is returned rather than dropped
+        return await this.#ask(exchange, payload, terms,
+          (buffer, properties) => this.#requests.route(exchange, key, buffer, { ...properties, mandatory: true }))
       }))
 
   consume = lazy(this, this.#createEventChannel,
@@ -221,6 +274,9 @@ class IO {
     this.#replies = await this.#createChannel('reply')
 
     this.#setupRetransmission()
+
+    // on a sharded connection, only once every shard has returned it
+    this.#requests.diagnose('return', this.#returned)
   }
 
   async #createEventChannel () {
@@ -351,21 +407,100 @@ class IO {
     })
 
   /**
+   * Sends a Request and returns what settles with its Reply, within the terms.
+   *
+   * @param {string} target the queue or the exchange the Request is published to
+   * @param {any} payload
+   * @param {comq.Terms} terms
+   * @param {(buffer: Buffer, properties: comq.amqp.options.Publish) => Promise<void>} publish
+   * @returns {Promise<any | Readable>}
+   */
+  async #ask (target, payload, terms, publish) {
+    const { signal, expires } = terms
+
+    signal?.throwIfAborted()
+
+    const [buffer, contentType] = this.#encode(payload, terms.encoding)
+    const request = this.#createRequest(target, contentType, signal)
+    const properties = { ...request.properties }
+
+    if (expires !== undefined) {
+      const left = Math.ceil(expires - Date.now())
+
+      // a re-send past the deadline, ahead of the timer that is about to end it
+      if (left <= 0) throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+
+      // what nobody has taken by the time its caller stops waiting, the broker drops
+      properties.expiration = String(left)
+    }
+
+    const reply = this.#createReply(request)
+
+    if (signal !== undefined) this.#abandon(request, reply, signal)
+
+    await abortable(publish(buffer, properties), signal)
+
+    return reply
+  }
+
+  /**
+   * Stops waiting for a Reply once the signal aborts. The Request is forgotten at once, so a
+   * retransmission leaves it be, and a Reply arriving later finds nobody waiting for it.
+   *
+   * @param {comq.Request} request
+   * @param {Promex} reply
+   * @param {AbortSignal} signal
+   */
+  #abandon (request, reply, signal) {
+    const abandon = () => {
+      request.emitter.off(request.properties.correlationId)
+      this.#pendingReplies.delete(reply)
+      reply.reject(signal.reason)
+    }
+
+    const settled = () => signal.removeEventListener('abort', abandon)
+
+    signal.addEventListener('abort', abandon, { once: true })
+    reply.then(settled, settled)
+  }
+
+  /**
+   * A Request the broker returned reached nobody, and nobody will answer it.
+   *
+   * @param {comq.amqp.Message} message
+   */
+  #returned = (message) => {
+    const { correlationId, replyTo } = message.properties
+
+    for (const [reply, request] of this.#pendingReplies) {
+      if (request.properties.correlationId !== correlationId) continue
+      if (request.emitter.queue !== replyTo) continue
+
+      request.emitter.off(correlationId)
+      this.#pendingReplies.delete(reply)
+      reply.reject(new Unroutable(message.fields.exchange, message.fields.routingKey))
+
+      return
+    }
+  }
+
+  /**
    * The request holds no copy of what was sent: a retransmission encodes the
    * payload anew, and an unanswered request would otherwise keep two of it.
    *
    * @param {string} queue
    * @param {comq.Encoding} contentType
+   * @param {AbortSignal} [signal]
    * @return {comq.Request}
    */
-  #createRequest (queue, contentType) {
+  #createRequest (queue, contentType, signal) {
     const emitter = this.#emitters.get(queue)
     const correlationId = emitter.next()
 
     /** @type {comq.amqp.Properties} */
     const properties = { contentType, correlationId, replyTo: emitter.queue }
 
-    return { emitter, properties }
+    return { emitter, properties, signal }
   }
 
   /**
@@ -416,6 +551,9 @@ class IO {
           // the stream has never started, hence the request is re-sent
           return reply.reject(RETRANSMISSION)
         }
+
+        // the caller stopped waiting while the stream was starting
+        if (request.signal?.aborted === true) return stream.destroy()
 
         reply.resolve(stream)
       } else {
@@ -549,6 +687,54 @@ const OCTETS = 'application/octet-stream'
 const DEFAULT = 'application/json'
 
 const RETRANSMISSION = /** @type {Error} */ Symbol('retransmission')
+
+/**
+ * What a caller passed, settled once: a timeout becomes the moment the Request expires, so that
+ * every attempt of it shares one deadline.
+ *
+ * @param {comq.Encoding | comq.RequestOptions} [options]
+ * @returns {comq.Terms}
+ */
+function terms (options) {
+  if (typeof options !== 'object' || options === null) return { encoding: options }
+
+  const { encoding, timeout, signal } = options
+  const signals = []
+
+  if (signal !== undefined) signals.push(signal)
+  if (timeout !== undefined) signals.push(AbortSignal.timeout(timeout))
+
+  return {
+    encoding,
+    expires: timeout === undefined ? undefined : Date.now() + timeout,
+    signal: signals.length === 0 ? undefined : AbortSignal.any(signals)
+  }
+}
+
+/**
+ * Waits for a publication, or for the signal to abort, whichever comes first. A publication
+ * waits out back pressure and a lost connection, and a caller that has stopped waiting is
+ * released from that too.
+ *
+ * @param {Promise<void>} publication
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<void>}
+ */
+async function abortable (publication, signal) {
+  if (signal === undefined) return await publication
+
+  let abort
+
+  const aborted = new Promise((_resolve, reject) => { abort = () => reject(signal.reason) })
+
+  signal.addEventListener('abort', abort, { once: true })
+
+  try {
+    await Promise.race([publication, aborted])
+  } finally {
+    signal.removeEventListener('abort', abort)
+  }
+}
 
 /**
  * A verdict answers what should happen to a message now that it has failed and nobody

--- a/source/io.js
+++ b/source/io.js
@@ -83,7 +83,10 @@ class IO {
    * @returns {Promise<any | Readable>}
    */
   request (queue, payload, options) {
-    return this.#request(queue, payload, terms(options))
+    const settled = terms(options)
+
+    // the channels and the queue a first Request declares are waited for within the terms too
+    return abortable(this.#request(queue, payload, settled), settled.signal)
   }
 
   /**
@@ -97,7 +100,9 @@ class IO {
    * @returns {Promise<any | Readable>}
    */
   call (exchange, key, payload, options) {
-    return this.#call(exchange, key, payload, terms(options))
+    const settled = terms(options)
+
+    return abortable(this.#call(exchange, key, payload, settled), settled.signal)
   }
 
   /**
@@ -712,16 +717,24 @@ function terms (options) {
 }
 
 /**
- * Waits for a publication, or for the signal to abort, whichever comes first. A publication
- * waits out back pressure and a lost connection, and a caller that has stopped waiting is
- * released from that too.
+ * Waits for a promise, or for the signal to abort, whichever comes first. Declaring a channel,
+ * a queue or publishing waits out back pressure and a lost connection, and a caller that has
+ * stopped waiting is released from all of it.
  *
- * @param {Promise<void>} publication
+ * @template T
+ * @param {Promise<T>} promise
  * @param {AbortSignal} [signal]
- * @returns {Promise<void>}
+ * @returns {Promise<T>}
  */
-async function abortable (publication, signal) {
-  if (signal === undefined) return await publication
+async function abortable (promise, signal) {
+  if (signal === undefined) return await promise
+
+  if (signal.aborted) {
+    // it settles later, with nobody waiting for it
+    promise.catch(() => undefined)
+
+    throw signal.reason
+  }
 
   let abort
 
@@ -730,7 +743,7 @@ async function abortable (publication, signal) {
   signal.addEventListener('abort', abort, { once: true })
 
   try {
-    await Promise.race([publication, aborted])
+    return await Promise.race([promise, aborted])
   } finally {
     signal.removeEventListener('abort', abort)
   }

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -69,8 +69,12 @@ class Channel {
     await this.#every((channel) => channel.bound(exchange, queue, key, consumer))
   }
 
+  /**
+   * A key is held once any shard holds it. A shard where another connection holds it goes on
+   * claiming it, and holds it as well once it is let go.
+   */
   async held (exchange, queue, key, consumer) {
-    await this.#every((channel) => channel.held(exchange, queue, key, consumer))
+    await Promise.any(this.#apply((channel) => channel.held(exchange, queue, key, consumer)))
   }
 
   async send (queue, buffer, options) {

--- a/source/shards/channel.js
+++ b/source/shards/channel.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Promex } = require('promex')
+const { RETRY_PREFIX } = require('../channel')
 const events = require('../events')
 const emitter = require('../emitter')
 
@@ -66,6 +67,10 @@ class Channel {
 
   async bound (exchange, queue, key, consumer) {
     await this.#every((channel) => channel.bound(exchange, queue, key, consumer))
+  }
+
+  async held (exchange, queue, key, consumer) {
+    await this.#every((channel) => channel.held(exchange, queue, key, consumer))
   }
 
   async send (queue, buffer, options) {
@@ -203,9 +208,11 @@ class Channel {
     const report = () => this.#diagnostics.emit(RETURN, message, channel.index)
     const attempt = (message.properties.headers?.[RETURN_HEADER] ?? 0) + 1
     const rest = this.#pool.filter((one) => one !== channel)
+    const { exchange, routingKey } = message.fields
 
-    // only replies are published to the default exchange, and only they are mandatory
-    const exhausted = message.fields.exchange !== DEFAULT ||
+    // a failed message waits on an exchange of comq's own, a fanout that is declared as one
+    // where it is consumed, and declaring it on another shard as anything else is refused
+    const exhausted = exchange.startsWith(RETRY_PREFIX) ||
       attempt >= this.#connections.length ||
       rest.length === 0
 
@@ -219,7 +226,13 @@ class Channel {
 
     const next = rest[Math.floor(Math.random() * rest.length)]
 
-    next.fire(message.fields.routingKey, message.content, properties).catch(report)
+    // a Request under a key goes through its routed exchange, which `route` declares on that
+    // shard before publishing: publishing to an exchange a broker lacks closes the connection
+    const retried = exchange === DEFAULT
+      ? next.fire(routingKey, message.content, properties)
+      : next.route(exchange, routingKey, message.content, properties)
+
+    retried.catch(report)
   }
 
   /**

--- a/source/unroutable.js
+++ b/source/unroutable.js
@@ -1,0 +1,27 @@
+'use strict'
+
+/**
+ * A Request the broker returned instead of routing: nothing was bound under its key, so it
+ * reached no one and did not run.
+ */
+class Unroutable extends Error {
+  /** @type {string} */
+  exchange
+
+  /** @type {string} */
+  key
+
+  /**
+   * @param {string} exchange
+   * @param {string} key
+   */
+  constructor (exchange, key) {
+    super(`Nothing is bound to '${exchange}' under '${key}'`)
+
+    this.name = 'Unroutable'
+    this.exchange = exchange
+    this.key = key
+  }
+}
+
+exports.Unroutable = Unroutable

--- a/test/amqplib.mock.js
+++ b/test/amqplib.mock.js
@@ -14,6 +14,7 @@ class Channel extends EventEmitter {
   assertQueue = jest.fn(async (name) => ({ queue: name ?? generate() }))
   assertExchange = jest.fn(async () => undefined)
   bindQueue = jest.fn(async () => undefined)
+  unbindQueue = jest.fn(async () => undefined)
   publish = jest.fn((_0, _1, _2, _3, resolve) => resolve?.(null))
   close = jest.fn(async () => undefined)
 }

--- a/test/channel.held.test.js
+++ b/test/channel.held.test.js
@@ -1,0 +1,223 @@
+'use strict'
+
+// region setup
+
+const { generate } = require('randomstring')
+const { timeout } = require('./helpers')
+
+const { amqplib } = require('./amqplib.mock')
+const fixtures = require('./channel.fixtures')
+const { create } = require('../source/channel')
+
+/** @type {jest.MockedObject<comq.amqp.Connection>} */
+let connection
+
+/** @type {comq.Topology} */
+let topology
+
+/** @type {comq.Channel} */
+let channel
+
+/** @type {jest.MockedObject<comq.amqp.Channel>} */
+let chan
+
+const exchange = generate()
+const queue = generate()
+const key = generate()
+const consumer = jest.fn()
+
+beforeEach(async () => {
+  jest.clearAllMocks()
+
+  global.COMQ_TESTING_LOCK_INTERVAL = 5
+
+  connection = await amqplib.connect()
+  topology = fixtures.preset()
+  channel = await create(connection, topology)
+  chan = await getCreatedChannel(connection)
+})
+
+afterEach(() => {
+  delete global.COMQ_TESTING_LOCK_INTERVAL
+})
+
+// endregion
+
+describe('held', () => {
+  it('should assert a direct exchange', async () => {
+    await channel.held(exchange, queue, key, consumer)
+
+    expect(chan.assertExchange).toHaveBeenCalledWith(exchange, 'direct', expect.anything())
+  })
+
+  it('should declare the queue exclusive on a channel of its own', async () => {
+    await channel.held(exchange, queue, key, consumer)
+
+    const [probe] = await getProbes(connection)
+
+    expect(probe.assertQueue).toHaveBeenCalledWith(queue, { exclusive: true })
+    expect(probe.close).toHaveBeenCalled()
+  })
+
+  it('should bind the queue under the key', async () => {
+    await channel.held(exchange, queue, key, consumer)
+
+    expect(chan.bindQueue).toHaveBeenCalledWith(queue, exchange, key)
+  })
+
+  it('should consume the queue', async () => {
+    await channel.held(exchange, queue, key, consumer)
+
+    expect(chan.consume).toHaveBeenCalledWith(queue, expect.any(Function), expect.any(Object))
+  })
+
+  it('should wait while another connection holds the queue', async () => {
+    const locked = jest.fn()
+
+    channel.diagnose('locked', locked)
+    lock(connection, { times: 2 })
+
+    await channel.held(exchange, queue, key, consumer)
+
+    expect(locked).toHaveBeenCalledTimes(2)
+    expect(locked).toHaveBeenCalledWith(queue)
+    expect(chan.consume).toHaveBeenCalledWith(queue, expect.any(Function), expect.any(Object))
+  })
+
+  it('should stop waiting once sealed', async () => {
+    lock(connection)
+
+    const holding = channel.held(exchange, queue, key, consumer)
+
+    await timeout(20)
+    await channel.seal()
+    await holding
+
+    expect(chan.bindQueue).not.toHaveBeenCalled()
+    expect(chan.consume).not.toHaveBeenCalled()
+  })
+
+  it('should reject on any other refusal', async () => {
+    lock(connection, { code: 403 })
+
+    await expect(channel.held(exchange, queue, key, consumer)).rejects.toBeDefined()
+  })
+})
+
+describe('seal', () => {
+  beforeEach(async () => {
+    await channel.held(exchange, queue, key, consumer)
+  })
+
+  it('should withdraw the key', async () => {
+    await channel.seal()
+
+    expect(chan.unbindQueue).toHaveBeenCalledWith(queue, exchange, key)
+  })
+
+  it('should withdraw the key before it stops consuming', async () => {
+    await channel.seal()
+
+    const [unbound] = chan.unbindQueue.mock.invocationCallOrder
+    const [cancelled] = chan.cancel.mock.invocationCallOrder
+
+    expect(unbound).toBeLessThan(cancelled)
+  })
+})
+
+describe('recovery', () => {
+  const other = generate()
+
+  beforeEach(async () => {
+    await channel.held(exchange, queue, key, consumer)
+    await channel.consume(other, consumer)
+  })
+
+  it('should hold the queue on the new connection', async () => {
+    const replacement = await amqplib.connect()
+
+    await channel.recover(replacement)
+    await timeout(5)
+
+    const repl = await getCreatedChannel(replacement)
+    const [probe] = await getProbes(replacement)
+
+    expect(probe.assertQueue).toHaveBeenCalledWith(queue, { exclusive: true })
+    expect(repl.bindQueue).toHaveBeenCalledWith(queue, exchange, key)
+  })
+
+  it('should restore the rest while the queue is held elsewhere', async () => {
+    const replacement = await amqplib.connect()
+
+    lock(replacement, { main: true })
+
+    const recovered = channel.recover(replacement).then(() => true)
+    const hung = timeout(200).then(() => false)
+
+    await expect(Promise.race([recovered, hung])).resolves.toStrictEqual(true)
+
+    const repl = await getCreatedChannel(replacement)
+
+    expect(repl.consume).toHaveBeenCalledWith(other, expect.any(Function), expect.any(Object))
+    expect(repl.bindQueue).not.toHaveBeenCalledWith(queue, exchange, key)
+
+    await channel.seal()
+  })
+})
+
+/**
+ * Makes the channels a connection creates from now on refuse an exclusive queue.
+ *
+ * @param {jest.MockedObject<comq.amqp.Connection>} conn
+ * @param {{ times?: number, code?: number, main?: boolean }} [options]
+ * `main` says the channel to be created first is the channel under test, which is left alone
+ */
+function lock (conn, { times = Infinity, code = 405, main = false } = {}) {
+  const create = conn.createChannel.getMockImplementation()
+  let skip = main && !topology.confirms
+  let refused = 0
+
+  conn.createChannel.mockImplementation(async () => {
+    const created = await create()
+
+    if (skip) {
+      skip = false
+
+      return created
+    }
+
+    if (refused < times) {
+      refused++
+
+      created.assertQueue.mockImplementation(async () => {
+        created.emit('error', Object.assign(new Error('Refused'), { code }))
+
+        throw new Error('Channel closed')
+      })
+    }
+
+    return created
+  })
+}
+
+/**
+ * @param {jest.MockedObject<comq.amqp.Connection>} conn
+ * @returns {Promise<jest.MockedObject<comq.amqp.Channel>>}
+ */
+function getCreatedChannel (conn) {
+  const method = `create${topology.confirms ? 'Confirm' : ''}Channel`
+
+  return conn[method].mock.results[0].value
+}
+
+/**
+ * The channels a connection created to declare an exclusive queue on.
+ *
+ * @param {jest.MockedObject<comq.amqp.Connection>} conn
+ * @returns {Promise<jest.MockedObject<comq.amqp.Channel>[]>}
+ */
+async function getProbes (conn) {
+  const created = await Promise.all(conn.createChannel.mock.results.map((result) => result.value))
+
+  return topology.confirms ? created : created.slice(1)
+}

--- a/test/channel.held.test.js
+++ b/test/channel.held.test.js
@@ -3,7 +3,6 @@
 // region setup
 
 const { generate } = require('randomstring')
-const { timeout } = require('./helpers')
 
 const { amqplib } = require('./amqplib.mock')
 const fixtures = require('./channel.fixtures')
@@ -29,16 +28,10 @@ const consumer = jest.fn()
 beforeEach(async () => {
   jest.clearAllMocks()
 
-  global.COMQ_TESTING_LOCK_INTERVAL = 5
-
   connection = await amqplib.connect()
   topology = fixtures.preset()
   channel = await create(connection, topology)
   chan = await getCreatedChannel(connection)
-})
-
-afterEach(() => {
-  delete global.COMQ_TESTING_LOCK_INTERVAL
 })
 
 // endregion
@@ -71,36 +64,13 @@ describe('held', () => {
     expect(chan.consume).toHaveBeenCalledWith(queue, expect.any(Function), expect.any(Object))
   })
 
-  it('should wait while another connection holds the queue', async () => {
-    const locked = jest.fn()
+  it.each([405, 403])('should reject with what the broker refused with (%d)', async (code) => {
+    lock(connection, { code })
 
-    channel.diagnose('locked', locked)
-    lock(connection, { times: 2 })
-
-    await channel.held(exchange, queue, key, consumer)
-
-    expect(locked).toHaveBeenCalledTimes(2)
-    expect(locked).toHaveBeenCalledWith(queue)
-    expect(chan.consume).toHaveBeenCalledWith(queue, expect.any(Function), expect.any(Object))
-  })
-
-  it('should stop waiting once sealed', async () => {
-    lock(connection)
-
-    const holding = channel.held(exchange, queue, key, consumer)
-
-    await timeout(20)
-    await channel.seal()
-    await holding
+    await expect(channel.held(exchange, queue, key, consumer)).rejects.toMatchObject({ code })
 
     expect(chan.bindQueue).not.toHaveBeenCalled()
     expect(chan.consume).not.toHaveBeenCalled()
-  })
-
-  it('should reject on any other refusal', async () => {
-    lock(connection, { code: 403 })
-
-    await expect(channel.held(exchange, queue, key, consumer)).rejects.toBeDefined()
   })
 })
 
@@ -126,18 +96,14 @@ describe('seal', () => {
 })
 
 describe('recovery', () => {
-  const other = generate()
-
   beforeEach(async () => {
     await channel.held(exchange, queue, key, consumer)
-    await channel.consume(other, consumer)
   })
 
   it('should hold the queue on the new connection', async () => {
     const replacement = await amqplib.connect()
 
     await channel.recover(replacement)
-    await timeout(5)
 
     const repl = await getCreatedChannel(replacement)
     const [probe] = await getProbes(replacement)
@@ -146,36 +112,26 @@ describe('recovery', () => {
     expect(repl.bindQueue).toHaveBeenCalledWith(queue, exchange, key)
   })
 
-  it('should restore the rest while the queue is held elsewhere', async () => {
+  it('should fail while another connection holds the queue', async () => {
     const replacement = await amqplib.connect()
 
     lock(replacement, { main: true })
 
-    const recovered = channel.recover(replacement).then(() => true)
-    const hung = timeout(200).then(() => false)
-
-    await expect(Promise.race([recovered, hung])).resolves.toStrictEqual(true)
-
-    const repl = await getCreatedChannel(replacement)
-
-    expect(repl.consume).toHaveBeenCalledWith(other, expect.any(Function), expect.any(Object))
-    expect(repl.bindQueue).not.toHaveBeenCalledWith(queue, exchange, key)
-
-    await channel.seal()
+    await expect(channel.recover(replacement)).rejects.toMatchObject({ code: 405 })
   })
 })
 
 /**
- * Makes the channels a connection creates from now on refuse an exclusive queue.
+ * Makes the channels a connection creates from now on refuse an exclusive queue, the way a
+ * broker does: by closing the channel, with the reason emitted as its error.
  *
  * @param {jest.MockedObject<comq.amqp.Connection>} conn
- * @param {{ times?: number, code?: number, main?: boolean }} [options]
+ * @param {{ code?: number, main?: boolean }} [options]
  * `main` says the channel to be created first is the channel under test, which is left alone
  */
-function lock (conn, { times = Infinity, code = 405, main = false } = {}) {
+function lock (conn, { code = 405, main = false } = {}) {
   const create = conn.createChannel.getMockImplementation()
   let skip = main && !topology.confirms
-  let refused = 0
 
   conn.createChannel.mockImplementation(async () => {
     const created = await create()
@@ -186,15 +142,11 @@ function lock (conn, { times = Infinity, code = 405, main = false } = {}) {
       return created
     }
 
-    if (refused < times) {
-      refused++
+    created.assertQueue.mockImplementation(async () => {
+      created.emit('error', Object.assign(new Error('Refused'), { code }))
 
-      created.assertQueue.mockImplementation(async () => {
-        created.emit('error', Object.assign(new Error('Refused'), { code }))
-
-        throw new Error('Channel closed')
-      })
-    }
+      throw new Error('Channel closed')
+    })
 
     return created
   })

--- a/test/channel.held.test.js
+++ b/test/channel.held.test.js
@@ -3,6 +3,7 @@
 // region setup
 
 const { generate } = require('randomstring')
+const { timeout, until } = require('./helpers')
 
 const { amqplib } = require('./amqplib.mock')
 const fixtures = require('./channel.fixtures')
@@ -28,10 +29,16 @@ const consumer = jest.fn()
 beforeEach(async () => {
   jest.clearAllMocks()
 
+  global.COMQ_TESTING_CLAIM_BACKOFF = { base: 5, max: 5 }
+
   connection = await amqplib.connect()
   topology = fixtures.preset()
   channel = await create(connection, topology)
   chan = await getCreatedChannel(connection)
+})
+
+afterEach(() => {
+  delete global.COMQ_TESTING_CLAIM_BACKOFF
 })
 
 // endregion
@@ -64,13 +71,36 @@ describe('held', () => {
     expect(chan.consume).toHaveBeenCalledWith(queue, expect.any(Function), expect.any(Object))
   })
 
-  it.each([405, 403])('should reject with what the broker refused with (%d)', async (code) => {
-    lock(connection, { code })
+  it('should claim the queue again while another connection holds it', async () => {
+    const taken = jest.fn()
 
-    await expect(channel.held(exchange, queue, key, consumer)).rejects.toMatchObject({ code })
+    channel.diagnose('taken', taken)
+    lock(connection, { times: 2 })
+
+    await channel.held(exchange, queue, key, consumer)
+
+    expect(taken).toHaveBeenCalledTimes(2)
+    expect(taken).toHaveBeenCalledWith(queue)
+    expect(chan.consume).toHaveBeenCalledWith(queue, expect.any(Function), expect.any(Object))
+  })
+
+  it('should stop claiming once sealed', async () => {
+    lock(connection)
+
+    const holding = channel.held(exchange, queue, key, consumer)
+
+    await timeout(20)
+    await channel.seal()
+    await holding
 
     expect(chan.bindQueue).not.toHaveBeenCalled()
     expect(chan.consume).not.toHaveBeenCalled()
+  })
+
+  it('should reject with any other refusal', async () => {
+    lock(connection, { code: 403 })
+
+    await expect(channel.held(exchange, queue, key, consumer)).rejects.toMatchObject({ code: 403 })
   })
 })
 
@@ -96,8 +126,15 @@ describe('seal', () => {
 })
 
 describe('recovery', () => {
+  const other = generate()
+
   beforeEach(async () => {
     await channel.held(exchange, queue, key, consumer)
+    await channel.consume(other, consumer)
+  })
+
+  afterEach(async () => {
+    await channel.seal()
   })
 
   it('should hold the queue on the new connection', async () => {
@@ -106,18 +143,38 @@ describe('recovery', () => {
     await channel.recover(replacement)
 
     const repl = await getCreatedChannel(replacement)
-    const [probe] = await getProbes(replacement)
 
-    expect(probe.assertQueue).toHaveBeenCalledWith(queue, { exclusive: true })
+    expect(await until(() => repl.bindQueue.mock.calls.some(([bound]) => bound === queue), 1000)).toStrictEqual(true)
     expect(repl.bindQueue).toHaveBeenCalledWith(queue, exchange, key)
   })
 
-  it('should fail while another connection holds the queue', async () => {
+  it('should restore the rest while another connection holds the queue', async () => {
     const replacement = await amqplib.connect()
 
     lock(replacement, { main: true })
 
-    await expect(channel.recover(replacement)).rejects.toMatchObject({ code: 405 })
+    const recovered = channel.recover(replacement).then(() => true)
+    const hung = timeout(200).then(() => false)
+
+    await expect(Promise.race([recovered, hung])).resolves.toStrictEqual(true)
+
+    const repl = await getCreatedChannel(replacement)
+
+    expect(repl.consume).toHaveBeenCalledWith(other, expect.any(Function), expect.any(Object))
+    expect(repl.bindQueue).not.toHaveBeenCalledWith(queue, exchange, key)
+  })
+
+  it('should hold the queue once it is let go', async () => {
+    const replacement = await amqplib.connect()
+
+    lock(replacement, { main: true, times: 2 })
+
+    await channel.recover(replacement)
+
+    const repl = await getCreatedChannel(replacement)
+
+    expect(await until(() => repl.bindQueue.mock.calls.some(([bound]) => bound === queue), 1000)).toStrictEqual(true)
+    expect(repl.bindQueue).toHaveBeenCalledWith(queue, exchange, key)
   })
 })
 
@@ -126,12 +183,13 @@ describe('recovery', () => {
  * broker does: by closing the channel, with the reason emitted as its error.
  *
  * @param {jest.MockedObject<comq.amqp.Connection>} conn
- * @param {{ code?: number, main?: boolean }} [options]
+ * @param {{ times?: number, code?: number, main?: boolean }} [options]
  * `main` says the channel to be created first is the channel under test, which is left alone
  */
-function lock (conn, { code = 405, main = false } = {}) {
+function lock (conn, { times = Infinity, code = 405, main = false } = {}) {
   const create = conn.createChannel.getMockImplementation()
   let skip = main && !topology.confirms
+  let refused = 0
 
   conn.createChannel.mockImplementation(async () => {
     const created = await create()
@@ -142,11 +200,15 @@ function lock (conn, { code = 405, main = false } = {}) {
       return created
     }
 
-    created.assertQueue.mockImplementation(async () => {
-      created.emit('error', Object.assign(new Error('Refused'), { code }))
+    if (refused < times) {
+      refused++
 
-      throw new Error('Channel closed')
-    })
+      created.assertQueue.mockImplementation(async () => {
+        created.emit('error', Object.assign(new Error('Refused'), { code }))
+
+        throw new Error('Channel closed')
+      })
+    }
 
     return created
   })

--- a/test/connection.mock.js
+++ b/test/connection.mock.js
@@ -10,6 +10,7 @@ const channel = /** @type {jest.MockedFunction<(sharded?: boolean, index?: numbe
     fire: jest.fn(async () => undefined),
     subscribe: jest.fn(async () => undefined),
     bound: jest.fn(async () => undefined),
+    held: jest.fn(async () => undefined),
     publish: jest.fn(async () => undefined),
     route: jest.fn(async () => undefined),
     diagnose: jest.fn(async () => undefined),

--- a/test/io.call.test.js
+++ b/test/io.call.test.js
@@ -1,0 +1,151 @@
+'use strict'
+
+// region setup
+
+const { randomBytes } = require('node:crypto')
+const { generate } = require('randomstring')
+const { immediate } = require('./helpers')
+const { encode } = require('../source/encode')
+const { Unroutable } = require('../source/unroutable')
+
+const mock = require('./connection.mock')
+const { IO } = require('../source/io')
+
+/** @type {comq.IO} */
+let io
+
+/** @type {jest.MockedObject<comq.Connection>} */
+let connection
+
+/** @type {jest.MockedObject<comq.Channel>} */
+let requests
+
+/** @type {jest.MockedObject<comq.Channel>} */
+let replies
+
+const exchange = generate()
+const key = generate()
+const payload = { [generate()]: generate() }
+
+beforeEach(async () => {
+  jest.clearAllMocks()
+
+  connection = mock.connection()
+  io = new IO(connection)
+})
+
+// endregion
+
+describe('call', () => {
+  /** @type {Promise<any>} */
+  let promise
+
+  beforeEach(async () => {
+    promise = io.call(exchange, key, payload)
+
+    // allows initializers to run
+    await immediate()
+
+    requests = await findChannel('request')
+    replies = await findChannel('reply')
+  })
+
+  it('should publish to the exchange under the key', async () => {
+    expect(requests.route).toHaveBeenCalledWith(exchange, key, expect.any(Buffer),
+      expect.objectContaining({ mandatory: true }))
+  })
+
+  it('should declare no queue to publish to', async () => {
+    expect(requests.send).not.toHaveBeenCalled()
+  })
+
+  it('should consume the queue it is answered to', async () => {
+    const properties = requests.route.mock.calls[0][3]
+
+    expect(replies.consume).toHaveBeenCalledWith(properties.replyTo, expect.any(Function))
+  })
+
+  it('should resolve with the reply', async () => {
+    const content = randomBytes(8)
+    const { correlationId } = requests.route.mock.calls[0][3]
+    const deliver = replies.consume.mock.calls[0][1]
+
+    await deliver({ content, properties: { correlationId } })
+
+    await expect(promise).resolves.toStrictEqual(content)
+  })
+
+  it('should reject with Unroutable once the broker returns it', async () => {
+    const properties = requests.route.mock.calls[0][3]
+
+    emit(requests, 'return', { content: randomBytes(8), fields: { exchange, routingKey: key }, properties })
+
+    await expect(promise).rejects.toBeInstanceOf(Unroutable)
+    await expect(promise).rejects.toMatchObject({ exchange, key })
+  })
+
+  it('should leave it waiting when another Request is returned', async () => {
+    const settled = jest.fn()
+    const properties = { ...requests.route.mock.calls[0][3], correlationId: generate() }
+
+    promise.then(settled, settled)
+
+    emit(requests, 'return', { content: randomBytes(8), fields: { exchange, routingKey: key }, properties })
+
+    await immediate()
+
+    expect(settled).not.toHaveBeenCalled()
+  })
+})
+
+describe('back', () => {
+  const producer = jest.fn(() => generate())
+
+  beforeEach(async () => {
+    await io.back(exchange, key, producer)
+
+    requests = await findChannel('request')
+  })
+
+  it('should hold a queue named after the exchange and the key', async () => {
+    expect(requests.held).toHaveBeenCalledWith(exchange, `${exchange}.${key}`, key, expect.any(Function))
+  })
+
+  it('should answer a Request', async () => {
+    const consumer = requests.held.mock.calls[0][3]
+    const contentType = 'application/json'
+    const properties = { contentType, correlationId: generate(), replyTo: generate() }
+
+    await consumer({ content: encode(payload, contentType), properties })
+
+    replies = await findChannel('reply')
+
+    expect(producer).toHaveBeenCalledWith(payload)
+
+    expect(replies.fire).toHaveBeenCalledWith(properties.replyTo, expect.any(Buffer),
+      expect.objectContaining({ correlationId: properties.correlationId }))
+  })
+})
+
+/**
+ * @param {comq.topology.type} type
+ * @returns {jest.MockedObject<comq.Channel>}
+ */
+const findChannel = (type) => {
+  const index = connection.createChannel.mock.calls.findIndex(([t]) => (t === type))
+
+  if (index === -1) throw new Error(`${type} channel hasn't been created`)
+
+  return connection.createChannel.mock.results[index].value
+}
+
+/**
+ * @param {jest.MockedObject<comq.Channel>} channel
+ * @param {string} event
+ * @param {...any} args
+ */
+function emit (channel, event, ...args) {
+  for (const [name, listener] of channel.diagnose.mock.calls) {
+    if (name === event) listener(...args)
+  }
+}

--- a/test/io.call.test.js
+++ b/test/io.call.test.js
@@ -98,6 +98,16 @@ describe('call', () => {
   })
 })
 
+describe('timeout', () => {
+  it('should stop waiting while the channels are being created', async () => {
+    connection.createChannel.mockImplementation(() => new Promise(() => undefined))
+
+    const promise = io.call(exchange, key, payload, { timeout: 20 })
+
+    await expect(promise).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+})
+
 describe('back', () => {
   const producer = jest.fn(() => generate())
 

--- a/test/io.request.terms.test.js
+++ b/test/io.request.terms.test.js
@@ -1,0 +1,228 @@
+'use strict'
+
+// region setup
+
+const { randomBytes } = require('node:crypto')
+const { generate } = require('randomstring')
+const { immediate, timeout } = require('./helpers')
+
+const mock = require('./connection.mock')
+const { IO } = require('../source/io')
+
+/** @type {comq.IO} */
+let io
+
+/** @type {jest.MockedObject<comq.Connection>} */
+let connection
+
+/** @type {jest.MockedObject<comq.Channel>} */
+let requests
+
+/** @type {jest.MockedObject<comq.Channel>} */
+let replies
+
+const queue = generate()
+const payload = { [generate()]: generate() }
+
+beforeEach(async () => {
+  jest.clearAllMocks()
+
+  connection = mock.connection()
+  io = new IO(connection)
+})
+
+// endregion
+
+describe('timeout', () => {
+  it('should expire the Request when the caller stops waiting', async () => {
+    io.request(queue, payload, { timeout: 10000 }).catch(noop)
+
+    await initialized()
+
+    const expiration = Number(requests.send.mock.calls[0][2].expiration)
+
+    expect(expiration).toBeGreaterThan(9000)
+    expect(expiration).toBeLessThanOrEqual(10000)
+  })
+
+  it('should keep the encoding', async () => {
+    const encoding = 'application/octet-stream'
+
+    io.request(queue, randomBytes(8), { encoding, timeout: 10000 }).catch(noop)
+
+    await initialized()
+
+    expect(requests.send.mock.calls[0][2].contentType).toStrictEqual(encoding)
+  })
+
+  it('should reject once it has passed', async () => {
+    const promise = io.request(queue, payload, { timeout: 20 })
+
+    await expect(promise).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
+  it('should resolve with a reply that arrives in time', async () => {
+    const promise = io.request(queue, payload, { timeout: 10000 })
+    const content = randomBytes(8)
+
+    await initialized()
+    await answer(0, content)
+
+    await expect(promise).resolves.toStrictEqual(content)
+  })
+
+  it('should re-send with the time that is left', async () => {
+    io.request(queue, payload, { timeout: 10000 }).catch(noop)
+
+    await initialized()
+    await timeout(20)
+
+    emit(requests, 'recover')
+
+    await immediate()
+
+    expect(requests.send).toHaveBeenCalledTimes(2)
+
+    const first = Number(requests.send.mock.calls[0][2].expiration)
+    const second = Number(requests.send.mock.calls[1][2].expiration)
+
+    expect(second).toBeLessThan(first)
+  })
+})
+
+describe('signal', () => {
+  it('should reject with the reason it was aborted for', async () => {
+    const controller = new AbortController()
+    const reason = new Error(generate())
+    const promise = io.request(queue, payload, { signal: controller.signal })
+
+    await initialized()
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+  })
+
+  it('should leave the Request in its queue', async () => {
+    const controller = new AbortController()
+
+    io.request(queue, payload, { signal: controller.signal }).catch(noop)
+
+    await initialized()
+
+    expect(requests.send.mock.calls[0][2].expiration).toBeUndefined()
+  })
+
+  it('should send nothing once aborted', async () => {
+    const controller = new AbortController()
+
+    // the channels exist before the aborted Request is made
+    io.request(queue, payload).catch(noop)
+
+    await initialized()
+
+    controller.abort()
+
+    await expect(io.request(queue, payload, { signal: controller.signal })).rejects.toBeDefined()
+
+    expect(requests.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not re-send what it abandoned', async () => {
+    const controller = new AbortController()
+    const promise = io.request(queue, payload, { signal: controller.signal })
+
+    await initialized()
+
+    controller.abort()
+
+    await promise.catch(noop)
+
+    emit(requests, 'recover')
+
+    await immediate()
+
+    expect(requests.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('should stop waiting for a publication', async () => {
+    io.request(queue, payload).catch(noop)
+
+    await initialized()
+
+    requests.send.mockImplementationOnce(() => new Promise(noop))
+
+    const controller = new AbortController()
+    const reason = new Error(generate())
+    const promise = io.request(queue, payload, { signal: controller.signal })
+
+    await immediate()
+
+    controller.abort(reason)
+
+    await expect(promise).rejects.toBe(reason)
+  })
+
+  it('should discard a reply that arrives afterwards', async () => {
+    const controller = new AbortController()
+    const promise = io.request(queue, payload, { signal: controller.signal })
+
+    await initialized()
+
+    controller.abort()
+
+    await promise.catch(noop)
+
+    await expect(answer(0)).resolves.toBeUndefined()
+  })
+
+  it('should end the wait within the timeout', async () => {
+    const controller = new AbortController()
+    const promise = io.request(queue, payload, { signal: controller.signal, timeout: 20 })
+
+    await expect(promise).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+})
+
+async function initialized () {
+  // allows initializers to run
+  await immediate()
+
+  requests = await findChannel('request')
+  replies = await findChannel('reply')
+}
+
+/**
+ * @param {number} index of the publication answered
+ * @param {Buffer} [content]
+ */
+async function answer (index, content = randomBytes(8)) {
+  const { correlationId } = requests.send.mock.calls[index][2]
+  const deliver = replies.consume.mock.calls[0][1]
+
+  await deliver({ content, properties: { correlationId } })
+}
+
+/**
+ * @param {comq.topology.type} type
+ * @returns {jest.MockedObject<comq.Channel>}
+ */
+const findChannel = (type) => {
+  const index = connection.createChannel.mock.calls.findIndex(([t]) => (t === type))
+
+  if (index === -1) throw new Error(`${type} channel hasn't been created`)
+
+  return connection.createChannel.mock.results[index].value
+}
+
+/**
+ * @param {jest.MockedObject<comq.Channel>} channel
+ * @param {string} event
+ */
+function emit (channel, event) {
+  for (const [name, listener] of channel.diagnose.mock.calls) {
+    if (name === event) listener()
+  }
+}
+
+function noop () {}

--- a/test/io.request.terms.test.js
+++ b/test/io.request.terms.test.js
@@ -55,6 +55,14 @@ describe('timeout', () => {
     expect(requests.send.mock.calls[0][2].contentType).toStrictEqual(encoding)
   })
 
+  it('should stop waiting while the channels are being created', async () => {
+    connection.createChannel.mockImplementation(() => new Promise(noop))
+
+    const promise = io.request(queue, payload, { timeout: 20 })
+
+    await expect(promise).rejects.toMatchObject({ name: 'TimeoutError' })
+  })
+
   it('should reject once it has passed', async () => {
     const promise = io.request(queue, payload, { timeout: 20 })
 
@@ -111,6 +119,17 @@ describe('signal', () => {
     await initialized()
 
     expect(requests.send.mock.calls[0][2].expiration).toBeUndefined()
+  })
+
+  it('should reject at once when aborted before the channels exist', async () => {
+    connection.createChannel.mockImplementation(() => new Promise(noop))
+
+    const controller = new AbortController()
+    const reason = new Error(generate())
+
+    controller.abort(reason)
+
+    await expect(io.request(queue, payload, { signal: controller.signal })).rejects.toBe(reason)
   })
 
   it('should send nothing once aborted', async () => {

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -569,6 +569,60 @@ describe('diagnose', () => {
     expect(listener).toHaveBeenCalledWith(message, index)
   })
 
+  it('should re-route a returned Request under a key on another shard', async () => {
+    const listener = /** @type {jest.MockedFunction} */ jest.fn()
+    const index = random(channels.length)
+    const chan = channels[index]
+    const message = returned()
+
+    message.fields.exchange = generate()
+    channel.diagnose('return', listener)
+
+    emitReturn(chan, message)
+
+    const rest = channels.filter((one) => one !== chan)
+
+    const properties = expect.objectContaining(
+      { mandatory: true, headers: { 'x-return': 1 } })
+
+    for (const one of rest) {
+      expect(one.route).toHaveBeenCalledWith(message.fields.exchange, message.fields.routingKey,
+        message.content, properties)
+    }
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('should report a returned retry at once', async () => {
+    const listener = /** @type {jest.MockedFunction} */ jest.fn()
+    const index = random(channels.length)
+    const chan = channels[index]
+    const message = returned()
+
+    message.fields.exchange = 'comq.retry.' + random(10000)
+    channel.diagnose('return', listener)
+
+    emitReturn(chan, message)
+
+    for (const one of channels) {
+      expect(one.fire).not.toHaveBeenCalled()
+      expect(one.route).not.toHaveBeenCalled()
+    }
+
+    expect(listener).toHaveBeenCalledWith(message, index)
+  })
+
+  it('should hold a queue on every shard', async () => {
+    const exchange = generate()
+    const queue = generate()
+    const key = generate()
+    const consumer = jest.fn()
+
+    await channel.held(exchange, queue, key, consumer)
+
+    for (const one of channels) expect(one.held).toHaveBeenCalledWith(exchange, queue, key, consumer)
+  })
+
   it('should emit `pause` and `unpause` events', async () => {
     const queue = generate()
     const buffer = randomBytes(8)

--- a/test/shards/channel.test.js
+++ b/test/shards/channel.test.js
@@ -623,6 +623,20 @@ describe('diagnose', () => {
     for (const one of channels) expect(one.held).toHaveBeenCalledWith(exchange, queue, key, consumer)
   })
 
+  it('should hold a queue once any shard holds it', async () => {
+    const [, ...rest] = channels
+
+    for (const one of rest) one.held.mockImplementationOnce(() => new Promise(() => undefined))
+
+    await expect(channel.held(generate(), generate(), generate(), jest.fn())).resolves.toBeUndefined()
+  })
+
+  it('should reject when every shard refuses to hold a queue', async () => {
+    for (const one of channels) one.held.mockImplementationOnce(async () => { throw new Error('refused') })
+
+    await expect(channel.held(generate(), generate(), generate(), jest.fn())).rejects.toBeInstanceOf(AggregateError)
+  })
+
   it('should emit `pause` and `unpause` events', async () => {
     const queue = generate()
     const buffer = randomBytes(8)

--- a/types/channel.d.ts
+++ b/types/channel.d.ts
@@ -22,6 +22,9 @@ declare namespace comq {
     /** consumes `queue`, bound to a routed `exchange` under `key` */
     bound (exchange: string, queue: string, key: string, consumer: channels.Consumer): Promise<void>
 
+    /** consumes `queue`, exclusive to this connection and bound to a routed `exchange` under `key` */
+    held (exchange: string, queue: string, key: string, consumer: channels.Consumer): Promise<void>
+
     send (queue: string, buffer: Buffer, options?: Options.Publish): Promise<void>
 
     publish (exchange: string, buffer: Buffer, options?: Options.Publish): Promise<void>

--- a/types/diagnostic.d.ts
+++ b/types/diagnostic.d.ts
@@ -1,7 +1,7 @@
 declare namespace comq.diagnostics {
 
   type Event = 'open' | 'close' | 'error' | 'reconnect' | 'exhausted' | 'flow' | 'drain' |
-    'remove' | 'lost' | 'recover' | 'discard' | 'retry' | 'pause' | 'resume' | 'return' | 'locked'
+    'remove' | 'lost' | 'recover' | 'discard' | 'retry' | 'pause' | 'resume' | 'return'
 
   interface Diagnosable {
     diagnose(event: Event, listener: Function): void

--- a/types/diagnostic.d.ts
+++ b/types/diagnostic.d.ts
@@ -1,7 +1,7 @@
 declare namespace comq.diagnostics {
 
   type Event = 'open' | 'close' | 'error' | 'reconnect' | 'exhausted' | 'flow' | 'drain' |
-    'remove' | 'lost' | 'recover' | 'discard' | 'retry' | 'pause' | 'resume' | 'return'
+    'remove' | 'lost' | 'recover' | 'discard' | 'retry' | 'pause' | 'resume' | 'return' | 'locked'
 
   interface Diagnosable {
     diagnose(event: Event, listener: Function): void

--- a/types/diagnostic.d.ts
+++ b/types/diagnostic.d.ts
@@ -1,7 +1,7 @@
 declare namespace comq.diagnostics {
 
   type Event = 'open' | 'close' | 'error' | 'reconnect' | 'exhausted' | 'flow' | 'drain' |
-    'remove' | 'lost' | 'recover' | 'discard' | 'retry' | 'pause' | 'resume' | 'return'
+    'remove' | 'lost' | 'recover' | 'discard' | 'retry' | 'pause' | 'resume' | 'return' | 'taken'
 
   interface Diagnosable {
     diagnose(event: Event, listener: Function): void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,3 +21,12 @@ export class Retry extends Error {}
  * the count like any other failure.
  */
 export class Park extends Error {}
+
+/**
+ * A Request `IO.call` sent under a key nobody holds. The broker returned it, so it reached no
+ * one and was not processed.
+ */
+export class Unroutable extends Error {
+  readonly exchange: string
+  readonly key: string
+}

--- a/types/io.d.ts
+++ b/types/io.d.ts
@@ -76,7 +76,8 @@ declare namespace comq {
 
     /**
      * Answers the Requests `call` sends under `key`, from a queue this connection alone holds.
-     * Rejects while another connection holds it.
+     * While another connection holds it on a broker, claims it there again and again, emitting
+     * `taken`. Resolves once a broker holds it.
      */
     back(exchange: string, key: string, produce: Producer): Promise<void>
 
@@ -143,6 +144,8 @@ declare namespace comq {
     diagnose(event: 'discard', listener: (channel: _topology.type, message: any, error: Error, index?: number) => void): void
 
     diagnose(event: 'retry', listener: (channel: _topology.type, message: any, error: Error, attempt: number, index?: number) => void): void
+
+    diagnose(event: 'taken', listener: (channel: _topology.type, queue: string, index?: number) => void): void
 
     diagnose(event: 'pause', listener: (channel: _topology.type) => void): void
 

--- a/types/io.d.ts
+++ b/types/io.d.ts
@@ -47,7 +47,10 @@ declare namespace comq {
      */
     timeout?: number
 
-    /** Ends the wait when aborted, within the timeout. A Request stays in its queue. */
+    /**
+     * Ends the wait when aborted, within the timeout. The Request stays in its queue until the
+     * timeout passes, or, without one, until a Producer takes it.
+     */
     signal?: AbortSignal
   }
 
@@ -73,7 +76,7 @@ declare namespace comq {
 
     /**
      * Answers the Requests `call` sends under `key`, from a queue this connection alone holds.
-     * While another connection holds it, waits for it to be let go.
+     * Rejects while another connection holds it.
      */
     back(exchange: string, key: string, produce: Producer): Promise<void>
 
@@ -140,8 +143,6 @@ declare namespace comq {
     diagnose(event: 'discard', listener: (channel: _topology.type, message: any, error: Error, index?: number) => void): void
 
     diagnose(event: 'retry', listener: (channel: _topology.type, message: any, error: Error, attempt: number, index?: number) => void): void
-
-    diagnose(event: 'locked', listener: (channel: _topology.type, queue: string, index?: number) => void): void
 
     diagnose(event: 'pause', listener: (channel: _topology.type) => void): void
 

--- a/types/io.d.ts
+++ b/types/io.d.ts
@@ -34,14 +34,48 @@ declare namespace comq {
   interface Request {
     emitter: ReplyEmitter
     properties: _amqp.Properties
+    signal?: AbortSignal
+  }
+
+  /** How long a caller waits for a Reply. */
+  interface RequestOptions {
+    encoding?: _encoding.Encoding
+
+    /**
+     * Milliseconds to wait for the Reply. A Request nobody has taken by then is dropped by the
+     * broker; one already taken may still be processed, and its Reply is discarded.
+     */
+    timeout?: number
+
+    /** Ends the wait when aborted, within the timeout. A Request stays in its queue. */
+    signal?: AbortSignal
+  }
+
+  /** The options of a Request, settled once for all its attempts. */
+  interface Terms {
+    encoding?: _encoding.Encoding
+    expires?: number
+    signal?: AbortSignal
   }
 
   interface IO extends _diagnostics.Diagnosable {
     reply(queue: string, produce: Producer): Promise<void>
 
-    request<Reply = any, Request = any>(queue: string, payload: Request, encoding?: _encoding.Encoding): Promise<Reply> | Promise<Readable>
+    request<Reply = any, Request = any>(queue: string, payload: Request, options?: _encoding.Encoding | RequestOptions): Promise<Reply> | Promise<Readable>
 
-    request(queue: string, stream: Readable, encoding?: _encoding.Encoding): Promise<Readable>
+    request(queue: string, stream: Readable, options?: _encoding.Encoding | RequestOptions): Promise<Readable>
+
+    /**
+     * Sends a Request to whoever holds `key` on the routed `exchange`, through `back`. One that
+     * nobody holds is refused with `Unroutable`.
+     */
+    call<Reply = any, Request = any>(exchange: string, key: string, payload: Request, options?: _encoding.Encoding | RequestOptions): Promise<Reply> | Promise<Readable>
+
+    /**
+     * Answers the Requests `call` sends under `key`, from a queue this connection alone holds.
+     * While another connection holds it, waits for it to be let go.
+     */
+    back(exchange: string, key: string, produce: Producer): Promise<void>
 
     consume<T = any>(exchange: string, group: string, consumer: Consumer<T>): Promise<void>
 
@@ -106,6 +140,8 @@ declare namespace comq {
     diagnose(event: 'discard', listener: (channel: _topology.type, message: any, error: Error, index?: number) => void): void
 
     diagnose(event: 'retry', listener: (channel: _topology.type, message: any, error: Error, attempt: number, index?: number) => void): void
+
+    diagnose(event: 'locked', listener: (channel: _topology.type, queue: string, index?: number) => void): void
 
     diagnose(event: 'pause', listener: (channel: _topology.type) => void): void
 


### PR DESCRIPTION
Part of stateful operations in Toa — the design is [`discussions/stateful.md`](https://github.com/toa-io/toa/blob/stateful/discussions/stateful.md) on the `stateful` branch there. Toa needs two things comq lacks: a Request that reaches one particular process rather than whichever takes it first, and a Request that can end.

## What it adds

```javascript
const { Unroutable } = require('comq')

await io.back('sessions', 'a1', (message) => sessions.get(message.id))

try {
  const session = await io.call('sessions', 'a1', { id: 7 }, { timeout: 5000 })
} catch (error) {
  if (error instanceof Unroutable) console.log('Nobody holds', error.key)
}
```

**`IO.back(exchange, key, producer)`** holds a Key: a queue named `<exchange>.<key>`, exclusive to the connection, bound to a direct exchange under the Key. On each broker one connection holds a Key at a time. While another connection holds it, `back` claims it again and again, emitting `taken` on every refusal, and returns once a broker holds it. Sealing withdraws every Key before it stops consuming.

**`IO.call(exchange, key, payload, options)`** publishes under the Key with `mandatory`, and ends in one of three ways: a Reply; `Unroutable` at once when nobody holds the Key, because the broker returns it; or its timeout, when the holder vanished without being sealed.

**`IO.request` and `IO.call` take `{ encoding, timeout, signal }`** where they took an encoding. The timeout bounds the whole wait — channels and queues a first Request declares, publishing, and the Reply — and rejects with the `TimeoutError` of `AbortSignal.timeout`. It is settled once for every attempt and published as the Request's expiration, so the broker drops what nobody took in time. A signal ends the wait with its reason and leaves the Request queued until its timeout, or until a Producer takes it.

**Additive.** An encoding passed as before behaves as before, and a Request without a timeout waits as it always has.

## Worth reviewing

- **This reverses "comq has no request timeout, and no way to withdraw a Request".** The readme and `rpc.parked.feature` are restated: a caller without a timeout keeps the certainty of an eventual answer, and a caller with one trades it for an end to the wait.
- **A taken Key is claimed again, and nothing else stops.** The broker refuses a queue another connection holds by closing the channel that asked, and comq's channels have no `error` listener, so today that closes the whole connection. The exclusive queue is declared on a channel of its own, which is all that closes. A refusal is reported as `taken` and the claim is made again with the backoff a lost connection is restored with — the broker announces nothing when a queue is let go. The rest of the connection works meanwhile, and a recovery restores everything else while the claim goes on. This covers a client that reconnected before the broker noticed its old connection was gone as well as a second process given the same Key.
- **Sharded returns.** A message returned from a non-default exchange used to be reported at once. A Request under a Key is now routed to the next shard through `route`, which declares the exchange there first; a copy returned from `comq.retry.*` is still reported at once, because that exchange is a fanout and declaring it as direct elsewhere is refused.
- **A Key over a sharded connection is held per broker.** `back` returns once any shard holds the Key; a shard where it is taken goes on claiming it, and holds it too once it is let go. Two processes given the same Key can hold it on different brokers and both answer calls — a configuration error, which `taken` reports on every attempt, and which heals by itself once one of them is gone.
- **`expiration` does not survive the retry ladder.** Dead-lettering strips it, so a Request that failed may run after its caller stopped waiting. Documented under Timeout.
- **`fix: a call that is sealed while it runs is not recorded`** is its own commit. `recall` threw when a seal reset the record under a call still running.
- **The silent network in the feature steps now keeps the broker's end open** once the client has given a silent connection up, which is what a broker that has not yet noticed looks like. It is what makes the refused recovery reproducible; the existing silent-connection scenarios pass with it.

## Verification

Crashes, restarts and a silent network are exercised against the real brokers in `rpc.call.recovery.feature` (`@heavy`):

- a holder holds its Key again after the broker restarts;
- a holder whose network went silent finds its Key taken while the broker holds the old connection, and holds it once the broker lets go;
- a call in flight when the broker crashes ends;
- a caller stops waiting for a request, and for a call, at its timeout while the broker is down;
- a request re-sent after a restart expires at its caller's deadline, and is never processed after it;
- over a sharded connection, a call reaches its holder while one of the brokers is down.

`rpc.call.feature` adds a holder that crashes — its caller stops waiting at its timeout, and the next call is refused — and a second holder that finds the Key taken and holds it once the first has closed. `rpc.call.shards.feature` adds a Key taken on one broker: it is held on the other, and on both once it is let go.

Two of these failed before the code was right, and were fixed rather than adjusted: the silent-network scenario showed the test network was closing the broker's end with the client's, and the timeout-while-down scenario showed that a first Request waited for its channels outside its timeout.

- `npm test`: 32 suites, 537 tests passed, standard clean.
- `npm run features`, `@heavy` included, against the two brokers: 85 scenarios, 654 steps passed.

Not run: anything against RabbitMQ 3.10 (the suite uses 4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
