### PR TITLE
perf: a socket sends a message without delay

### DIFF
--- a/features/silence.feature
+++ b/features/silence.feature
@@ -57,6 +57,7 @@ Feature: Silent Connection Tolerance
   Scenario: Reporting that there is nowhere left to publish
     Given an active sharded connection
     And a producer replying `echo` queue
-    When the network goes silent
+    When the network goes silent and refuses new connections
     Then publishing is paused within 10 seconds
-    And publishing is resumed within 10 seconds
+    When the network admits new connections
+    Then publishing is resumed within 10 seconds

--- a/features/steps/network.js
+++ b/features/steps/network.js
@@ -26,6 +26,24 @@ When('the network goes silent',
     silence.call(this)
   })
 
+When('the network goes silent and refuses new connections',
+  /**
+   * @this {comq.features.Context}
+   */
+  function () {
+    for (const network of this.networks) network.refuse()
+
+    silence.call(this)
+  })
+
+When('the network admits new connections',
+  /**
+   * @this {comq.features.Context}
+   */
+  function () {
+    for (const network of this.networks) network.admit()
+  })
+
 When('the silent connection is let go',
   /**
    * @this {comq.features.Context}

--- a/features/steps/networks.js
+++ b/features/steps/networks.js
@@ -23,6 +23,8 @@ class Network {
   /** @type {number} */
   #port
 
+  #refusing = false
+
   /**
    * @param {number} [n] broker index
    */
@@ -52,6 +54,18 @@ class Network {
   }
 
   /**
+   * A connection established from now on is closed as soon as it is accepted, so
+   * a connection that is lost stays lost until the network admits it.
+   */
+  refuse () {
+    this.#refusing = true
+  }
+
+  admit () {
+    this.#refusing = false
+  }
+
+  /**
    * Closes the tunnels that went silent, at both ends, so the broker learns that the
    * connection it was still holding is gone — the moment its heartbeat would otherwise tell it.
    */
@@ -69,6 +83,8 @@ class Network {
    * @param {net.Socket} client
    */
   #tunnel = (client) => {
+    if (this.#refusing) return client.destroy()
+
     const upstream = net.connect(this.#port, this.#host)
 
     /** @type {comq.features.Tunnel} */

--- a/source/connection.js
+++ b/source/connection.js
@@ -371,6 +371,8 @@ const SHUTDOWN_MS = 5_000
 
 const SOCKET_OPTIONS = {
   timeout: CONNECT_MS,
+  // a message is written once and is small, which is what Nagle's algorithm holds back
+  noDelay: true,
   // a peer that went away without a word is noticed by the kernel as well
   keepAlive: true,
   keepAliveDelay: KEEPALIVE_MS

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -684,6 +684,13 @@ describe('heartbeat', () => {
     expect(amqplib.connect)
       .toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ keepAlive: true }))
   })
+
+  it('should send without delay', async () => {
+    await connection.open()
+
+    expect(amqplib.connect)
+      .toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ noDelay: true }))
+  })
 })
 
 describe('close', () => {


### PR DESCRIPTION
Every comq socket runs with Nagle's algorithm. amqplib calls `sock.setNoDelay(!!sockopts.noDelay)` on both `amqp:` and `amqps:` sockets, and `SOCKET_OPTIONS` sets no `noDelay`, so it ends up `setNoDelay(false)`. A small write that follows one the broker has not yet acknowledged is then held until the broker's delayed ACK arrives, which takes up to about 40 ms on Linux.

The messages comq sends are what the algorithm holds back and nothing it helps with. amqplib writes a message whose frames total under 2,048 bytes as one buffer, and requests, replies and acks are each a few hundred bytes. RabbitMQ's `tcp_listen_options` default to `{nodelay, true}`, so the client is the only side that holds writes back.

## What changes

`SOCKET_OPTIONS` carries `noDelay: true` beside `keepAlive`.

**The scenario "Reporting that there is nowhere left to publish" keeps both shards unreachable at once.** A sharded channel pauses only while every shard's connection is down at the same moment. The scenario silenced the network and let the watchdog drop both connections, but the network forwards a connection opened afterwards, so each shard reconnected at once. With Nagle's algorithm on, both connections were dropped in the same millisecond and took about 44 ms to come back, so the two outages overlapped and `pause` came. With `noDelay` the watchdogs fire about 38 ms apart and each shard is back within 3 ms, so one shard is always reachable and `pause` rightly never comes. The network now refuses new connections while it is silent, and admits them before `resume` is expected, so the outage lasts as long as the scenario says. The old scenario failed three runs out of three with `noDelay` and passed three out of three without it; the new one passed three out of three either way, with `resume` about a second after `pause`, which is comq's first reconnect delay.

## Measured

A request-reply round trip at a fixed rate against a running RabbitMQ, with the requester and the replier on separate connections, 1,000 requests per rate:

| rate, rps | before p50 | before p90 | before p99 | after p50 | after p90 | after p99 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 100 | 2.83 ms | 41.42 ms | 42.33 ms | 0.52 ms | 0.69 ms | 0.81 ms |
| 400 | 3.78 ms | 41.43 ms | 42.22 ms | 0.31 ms | 0.40 ms | 0.51 ms |
| 800 | 3.46 ms | 41.44 ms | 42.25 ms | 0.27 ms | 0.33 ms | 0.43 ms |

Through Toa's whole request path (gateway, component, MongoDB), the same one-line change moved the p50 of a trivial request from 10.36 ms to 0.68 ms at 100 rps, and saturation from 13,271 to 14,587 rps. For a request that reads storage, saturation went from 3,781 to 9,170 rps. A hand-written baseline over plain amqplib has the same floor with amqplib's default and loses it with `noDelay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
