### PR TITLE
release: a socket sends a message without delay

### DIFF
--- a/features/silence.feature
+++ b/features/silence.feature
@@ -57,6 +57,7 @@ Feature: Silent Connection Tolerance
   Scenario: Reporting that there is nowhere left to publish
     Given an active sharded connection
     And a producer replying `echo` queue
-    When the network goes silent
+    When the network goes silent and refuses new connections
     Then publishing is paused within 10 seconds
-    And publishing is resumed within 10 seconds
+    When the network admits new connections
+    Then publishing is resumed within 10 seconds

--- a/features/steps/network.js
+++ b/features/steps/network.js
@@ -26,6 +26,24 @@ When('the network goes silent',
     silence.call(this)
   })
 
+When('the network goes silent and refuses new connections',
+  /**
+   * @this {comq.features.Context}
+   */
+  function () {
+    for (const network of this.networks) network.refuse()
+
+    silence.call(this)
+  })
+
+When('the network admits new connections',
+  /**
+   * @this {comq.features.Context}
+   */
+  function () {
+    for (const network of this.networks) network.admit()
+  })
+
 When('the silent connection is let go',
   /**
    * @this {comq.features.Context}

--- a/features/steps/networks.js
+++ b/features/steps/networks.js
@@ -23,6 +23,8 @@ class Network {
   /** @type {number} */
   #port
 
+  #refusing = false
+
   /**
    * @param {number} [n] broker index
    */
@@ -52,6 +54,18 @@ class Network {
   }
 
   /**
+   * A connection established from now on is closed as soon as it is accepted, so
+   * a connection that is lost stays lost until the network admits it.
+   */
+  refuse () {
+    this.#refusing = true
+  }
+
+  admit () {
+    this.#refusing = false
+  }
+
+  /**
    * Closes the tunnels that went silent, at both ends, so the broker learns that the
    * connection it was still holding is gone — the moment its heartbeat would otherwise tell it.
    */
@@ -69,6 +83,8 @@ class Network {
    * @param {net.Socket} client
    */
   #tunnel = (client) => {
+    if (this.#refusing) return client.destroy()
+
     const upstream = net.connect(this.#port, this.#host)
 
     /** @type {comq.features.Tunnel} */

--- a/source/connection.js
+++ b/source/connection.js
@@ -371,6 +371,8 @@ const SHUTDOWN_MS = 5_000
 
 const SOCKET_OPTIONS = {
   timeout: CONNECT_MS,
+  // a message is written once and is small, which is what Nagle's algorithm holds back
+  noDelay: true,
   // a peer that went away without a word is noticed by the kernel as well
   keepAlive: true,
   keepAliveDelay: KEEPALIVE_MS

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -684,6 +684,13 @@ describe('heartbeat', () => {
     expect(amqplib.connect)
       .toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ keepAlive: true }))
   })
+
+  it('should send without delay', async () => {
+    await connection.open()
+
+    expect(amqplib.connect)
+      .toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ noDelay: true }))
+  })
 })
 
 describe('close', () => {


### PR DESCRIPTION
Releases #283.

`semantic-release` will cut a **patch** off the `perf:` — `0.20.0` → `0.20.1`. Nothing else changes for a caller: the API, the topology and the wire format stay as they are.

## What ships

**#283 — a socket sends a message without delay.** comq connects with `noDelay: true` in `SOCKET_OPTIONS`. Without it amqplib calls `setNoDelay(false)`, and a small write that follows one the broker has not yet acknowledged waits for the broker's delayed ACK, up to about 40 ms on Linux. A request-reply round trip against a running RabbitMQ at 100 requests per second went from a p90 of 41.42 ms to 0.69 ms; through Toa's whole request path, a trivial request went from a p50 of 10.36 ms to 0.68 ms.

**#283 — a scenario that no longer depends on timing.** "Reporting that there is nowhere left to publish" now keeps both shards unreachable at once by refusing new connections while the network is silent, instead of relying on reconnects slower than the gap between the two watchdogs.

## Verified on the branch

- `npm test` — 32 suites, 538 unit tests, `standard` clean.
- `npm run features`, `@heavy` included — 85 scenarios, 655 steps against the two brokers.

Wanted by Toa's performance work — [`discussions/performance.md`](https://github.com/toa-io/toa/blob/benchmarks/discussions/performance.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
