### PR TITLE
A turn's frames leave in one write

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/benchmarks/readme.md
+++ b/benchmarks/readme.md
@@ -1,0 +1,65 @@
+# Benchmarks
+
+What one request costs the peer that answers it: the CPU it spends, the socket writes it makes,
+and what the caller waits.
+
+```shell
+$ docker compose up -d
+$ npm run benchmark
+```
+
+The peer runs in a process of its own — that is where its CPU is read from — and answers an echo
+of a small object over `request`/`reply` on the broker `docker-compose.yaml` starts.
+
+## What it reports
+
+Two tables, because the two say different things.
+
+**At a fixed rate** sends what a rate calls for and does not wait for the answers, which is how
+traffic arrives. A rate below what the peer can serve is the honest place to read latency.
+
+**With requests in flight** keeps a fixed number of them outstanding, which is how a queue of
+callers behaves, and at a high enough number it is where the peer saturates: the rate column is
+then what the peer can serve, and the CPU column is what one message costs it there.
+
+Each row carries:
+
+| column | what it is |
+| --- | --- |
+| `messages/s` | answered in the window, over its length |
+| `CPU µs` | user and system time of the answering process, per message |
+| `writes`, `writev` | socket write calls of the answering process, per message |
+| `p50`, `p99` | what the caller waited, milliseconds |
+
+`writes` and `writev` are the mechanism, not the outcome: a message the library writes as its own
+syscall costs more than one written together with its neighbours.
+
+## Reading a result
+
+A number here means something only beside another number from the same machine. Run it on the
+revision you are changing, then on your change, and compare the columns; a difference under about
+5% between two rounds of the same revision is what this machine's noise looks like.
+
+Both rounds are printed rather than averaged, so a run that drifted is visible as a run that
+drifted.
+
+## Options
+
+| option | default | what it does |
+| --- | --- | --- |
+| `--rates` | `1000,5000,20000,40000` | messages a second for the fixed-rate table |
+| `--concurrency` | `1,8,64,256` | requests in flight for the second table |
+| `--messages` | `20000` | messages per window, in flight mode |
+| `--seconds` | `6` | length of a window, fixed-rate mode |
+| `--rounds` | `2` | how many times the whole matrix is measured |
+
+`COMQ_BENCHMARK_URL` points the run at another broker.
+
+```shell
+$ npm run benchmark -- --rates 5000 --concurrency 64 --rounds 3
+```
+
+## What it does not measure
+
+Streams, confirms, sharded or singleton connections, and recovery. It measures the path a request
+and its reply take, which is the one every other path is built on.

--- a/benchmarks/run.js
+++ b/benchmarks/run.js
@@ -1,0 +1,196 @@
+// What one request costs the process that answers it. See readme.md.
+//
+// node benchmarks/run.js [--rates 1000,5000] [--concurrency 1,8] [--messages 20000]
+// [--seconds 6] [--rounds 2]
+
+import { fork } from 'node:child_process'
+import { parseArgs } from 'node:util'
+import { createRequire } from 'node:module'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const require = createRequire(import.meta.url)
+const { connect } = require('../source/index.js')
+
+const { values } = parseArgs({
+  options: {
+    rates: { type: 'string', default: '1000,5000,20000,40000' },
+    concurrency: { type: 'string', default: '1,8,64,256' },
+    messages: { type: 'string', default: '20000' },
+    seconds: { type: 'string', default: '6' },
+    rounds: { type: 'string', default: '2' }
+  }
+})
+
+const url = process.env.COMQ_BENCHMARK_URL ?? 'amqp://developer:secret@localhost:5673'
+const rates = numbers(values.rates)
+const concurrencies = numbers(values.concurrency)
+const messages = Number(values.messages)
+const seconds = Number(values.seconds)
+const rounds = Number(values.rounds)
+
+const durations = []
+
+/** What a request carries, which is small, as a call between components is. */
+const payload = {
+  id: '4c4759e6f9c74da989d64511df42d6f4',
+  title: 'First pot',
+  rank: 7,
+  public: true,
+  tags: ['one', 'two', 'three']
+}
+
+const server = await start()
+const io = await connect(url)
+
+try {
+  const open = []
+  const closed = []
+
+  for (let round = 1; round <= rounds; round++) {
+    for (const rate of rates) open.push(await atRate(rate, round))
+    for (const concurrency of concurrencies) closed.push(await inFlight(concurrency, round))
+  }
+
+  report('At a fixed rate', ['rate'], open)
+  report('With requests in flight', ['in flight'], closed)
+} finally {
+  await io.close()
+
+  server.kill()
+}
+
+/**
+ * Requests sent at a rate, as traffic arrives: a millisecond's worth at a time, none of them
+ * waited for. What a peer costs per message is read from the peer itself.
+ */
+async function atRate (rate, round) {
+  await load(() => send(rate, 2, false))
+
+  const measured = await load(() => send(rate, seconds, true))
+
+  return { round, of: rate, ...measured }
+}
+
+/** Requests kept in flight, as a queue of callers is: the peer is never idle between them. */
+async function inFlight (concurrency, round) {
+  await load(() => saturate(concurrency, Math.min(5000, messages), false))
+
+  const measured = await load(() => saturate(concurrency, messages, true))
+
+  return { round, of: concurrency, ...measured }
+}
+
+/** A window: what the peer spent, and what the caller waited, between two readings. */
+async function load (work) {
+  durations.length = 0
+
+  const before = await io.request('comq.benchmark.meter', null)
+  const started = process.hrtime.bigint()
+
+  await work()
+
+  const elapsed = Number(process.hrtime.bigint() - started) / 1e9
+  const after = await io.request('comq.benchmark.meter', null)
+  const answered = after.answered - before.answered
+  const cpu = after.cpu.user + after.cpu.system - before.cpu.user - before.cpu.system
+
+  return {
+    answered,
+    rate: Math.round(answered / elapsed),
+    cpu: round2(cpu / answered),
+    writes: round3((after.write - before.write) / answered),
+    writevs: round3((after.writev - before.writev) / answered),
+    p50: percentile(0.5),
+    p99: percentile(0.99)
+  }
+}
+
+async function send (rate, duration, record) {
+  const started = process.hrtime.bigint()
+  const pending = []
+
+  let sent = 0
+
+  while (elapsed(started) < duration) {
+    const due = Math.round(elapsed(started) * rate)
+
+    while (sent < due) {
+      sent++
+      pending.push(request(record))
+    }
+
+    await sleep(1)
+  }
+
+  await Promise.all(pending)
+}
+
+async function saturate (concurrency, count, record) {
+  let sent = 0
+
+  const caller = async () => {
+    while (sent < count) {
+      sent++
+
+      await request(record)
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, caller))
+}
+
+async function request (record) {
+  const at = process.hrtime.bigint()
+
+  await io.request('comq.benchmark.echo', payload)
+
+  if (record) durations.push(Number(process.hrtime.bigint() - at) / 1e6)
+}
+
+function report (title, columns, rows) {
+  console.log(`\n## ${title}\n`)
+  console.log(`| ${columns[0]} | round | messages/s | CPU µs | writes | writev | p50 ms | p99 ms |`)
+  console.log('| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |')
+
+  for (const row of rows) {
+    console.log(`| ${row.of} | ${row.round} | ${row.rate} | ${row.cpu} | ${row.writes} | ` +
+      `${row.writevs} | ${row.p50} | ${row.p99} |`)
+  }
+}
+
+/** The peer in a process of its own, which is where its CPU is measured. */
+async function start () {
+  const child = fork(new URL('server.js', import.meta.url), { stdio: 'inherit' })
+
+  await new Promise((resolve, reject) => {
+    child.once('message', resolve)
+    child.once('exit', (code) => reject(new Error(`The peer exited with ${code}`)))
+  })
+
+  return child
+}
+
+function percentile (share) {
+  // a warm-up window records nothing, and its result is discarded
+  if (durations.length === 0) return 0
+
+  const sorted = durations.slice().sort((a, b) => a - b)
+
+  return round3(sorted[Math.floor(sorted.length * share)])
+}
+
+function elapsed (since) {
+  return Number(process.hrtime.bigint() - since) / 1e9
+}
+
+function numbers (list) {
+  return list.split(',').map(Number)
+}
+
+function round2 (value) {
+  return Number(value.toFixed(2))
+}
+
+function round3 (value) {
+  return Number(value.toFixed(3))
+}

--- a/benchmarks/server.js
+++ b/benchmarks/server.js
@@ -1,0 +1,47 @@
+// The peer under measurement: it answers an echo, and reports what answering cost it.
+//
+// The socket's write methods are counted here rather than in the library, because what a message
+// costs a process is mostly the syscalls it makes: a reply and the acknowledgement of the request
+// it answers are two writes unless something puts them together.
+
+import net from 'node:net'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const { connect } = require('../source/index.js')
+
+const counters = { write: 0, writev: 0, chunks: 0 }
+const write = net.Socket.prototype._write
+const writev = net.Socket.prototype._writev
+
+net.Socket.prototype._write = function (...args) {
+  counters.write++
+  counters.chunks++
+
+  return write.apply(this, args)
+}
+
+net.Socket.prototype._writev = function (chunks, ...rest) {
+  counters.writev++
+  counters.chunks += chunks.length
+
+  return writev.apply(this, [chunks, ...rest])
+}
+
+const url = process.env.COMQ_BENCHMARK_URL ?? 'amqp://developer:secret@localhost:5673'
+
+let answered = 0
+
+const io = await connect(url)
+
+await io.reply('comq.benchmark.echo', (payload) => {
+  answered++
+
+  return payload
+})
+
+// read before and after a window, so what is reported is what that window cost
+await io.reply('comq.benchmark.meter', () => ({ answered, cpu: process.cpuUsage(), ...counters }))
+
+process.send?.('ready')
+console.log('ready')

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test": "standard && jest",
     "features": "cucumber-js --fail-fast -t 'not @manual'",
     "features:fast": "cucumber-js --fail-fast -t 'not @manual and not @heavy'",
+    "benchmark": "node benchmarks/run.js",
     "lint": "standard --fix --verbose | snazzy"
   },
   "standard": {

--- a/source/batch.js
+++ b/source/batch.js
@@ -1,0 +1,62 @@
+'use strict'
+
+/**
+ * Writes as one what a connection sends in one turn of the event loop.
+ *
+ * amqplib hands its frames to the socket one write at a time, and a request served is two of
+ * them: the reply, and the acknowledgement of the request it answers. With Nagle's algorithm off,
+ * which is what a socket sending without delay runs under, each is a syscall and a packet of its
+ * own. Corked, they are held in the socket's buffer and leave together, in one `writev`, at the
+ * end of the same turn: nothing waits for a timer, and nothing waits for a write that may never
+ * come.
+ *
+ * This belongs in amqplib, whose loop does the writing, and is proposed there:
+ * https://github.com/temich/amqplib/tree/perf/one-write-per-turn. It is done here until that
+ * lands, and goes when it does.
+ *
+ * @param {import('node:net').Socket} socket
+ */
+function batch (socket) {
+  // whatever a connection is carried over is left as it is unless it is a stream that corks
+  if (!corkable(socket) || socket[BATCHED] === true) return
+
+  socket[BATCHED] = true
+
+  const write = socket.write.bind(socket)
+
+  const flush = () => {
+    socket[CORKED] = false
+    socket.uncork()
+  }
+
+  const cork = () => {
+    if (socket[CORKED] === true) return
+
+    socket[CORKED] = true
+    socket.cork()
+
+    process.nextTick(flush)
+  }
+
+  socket.write = (...args) => {
+    cork()
+
+    return write(...args)
+  }
+}
+
+/**
+ * @param {any} socket
+ * @returns {boolean}
+ */
+function corkable (socket) {
+  return socket !== null && socket !== undefined &&
+    typeof socket.write === 'function' &&
+    typeof socket.cork === 'function' &&
+    typeof socket.uncork === 'function'
+}
+
+const BATCHED = Symbol('comq.batched')
+const CORKED = Symbol('comq.corked')
+
+exports.batch = batch

--- a/source/connection.js
+++ b/source/connection.js
@@ -6,6 +6,7 @@ const { Promex } = require('promex')
 const { retry } = require('reretry')
 
 const { failsafe } = require('./attributes')
+const { batch } = require('./batch')
 const presets = require('./topology')
 const channels = require('./channel')
 const emitter = require('./emitter')
@@ -146,6 +147,9 @@ class Connection {
 
     connection.on('close', (error) => this.#close(connection, error))
     this.#connection = connection
+
+    batch(connection.connection?.stream)
+
     this.#armWatchdog(connection)
     this.#diagnostics.emit('open')
 

--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const { Writable } = require('node:stream')
+
+const { batch } = require('../source/batch')
+
+/** A socket, as far as writing to it goes: what it was given, and how many times. */
+function socket () {
+  const writes = []
+
+  return Object.assign(new Writable({
+    write (chunk, _encoding, callback) {
+      writes.push([chunk.toString()])
+      callback()
+    },
+    writev (chunks, callback) {
+      writes.push(chunks.map(({ chunk }) => chunk.toString()))
+      callback()
+    }
+  }), { writes })
+}
+
+const tick = () => new Promise((resolve) => process.nextTick(resolve))
+
+it('should be', async () => {
+  expect(batch).toBeDefined()
+})
+
+it('should write what a turn wrote as one', async () => {
+  const stream = socket()
+
+  batch(stream)
+
+  stream.write('a')
+  stream.write('b')
+
+  await tick()
+
+  expect(stream.writes).toStrictEqual([['a', 'b']])
+})
+
+it('should write what a later turn wrote on its own', async () => {
+  const stream = socket()
+
+  batch(stream)
+
+  stream.write('a')
+
+  await tick()
+
+  stream.write('b')
+
+  await tick()
+
+  expect(stream.writes).toStrictEqual([['a'], ['b']])
+})
+
+it('should not hold a write past its turn', async () => {
+  const stream = socket()
+
+  batch(stream)
+
+  stream.write('a')
+
+  await tick()
+
+  expect(stream.writes).toStrictEqual([['a']])
+})
+
+it('should take a socket once', async () => {
+  const stream = socket()
+
+  batch(stream)
+
+  const wrapped = stream.write
+
+  batch(stream)
+
+  expect(stream.write).toStrictEqual(wrapped)
+})
+
+it('should leave alone what does not cork', async () => {
+  for (const value of [undefined, null, {}, { write: () => undefined }]) {
+    expect(() => batch(value)).not.toThrow()
+  }
+
+  const written = []
+  const plain = { write: (chunk) => written.push(chunk) }
+
+  batch(plain)
+  plain.write('a')
+
+  expect(written).toStrictEqual(['a'])
+})


### PR DESCRIPTION
Two commits: a benchmark of the request/reply path, and the write batching it measures. Built on `dev` with #286, the Reply stream fix, merged.

## The benchmark

`npm run benchmark` (broker from `docker compose up -d`) reports what one request costs the peer that answers it — its CPU, its socket writes, and what the caller waits — at fixed rates, as traffic arrives, and with requests in flight, as a queue of callers behaves. `benchmarks/readme.md` says how to read it and what it leaves out.

## The change

amqplib writes each frame to the socket on its own, and a served request is two of them: the reply, and the acknowledgement of the request it answers. With `noDelay` — which comq sets since 0.20.1 — each is a syscall and a packet. The socket is corked when a turn writes its first frame and uncorked on the next tick, so the turn's frames leave in one `writev`; nothing waits for a timer.

Measured with the benchmark above, both rounds, one machine:

| rate/s | CPU µs before | after | p50 ms before | after | writes → writev |
| ---: | ---: | ---: | ---: | ---: | --- |
| 1,000 | 55.3 / 41.1 | 52.1 / 37.9 | 0.316 / 0.281 | 0.306 / 0.269 | 2 → 0.97 |
| 5,000 | 25.2 / 24.5 | 15.8 / 16.0 | 0.420 / 0.416 | 0.448 / 0.427 | 2 → 0.30 |
| 20,000 | 20.0 / 19.9 | 12.1 / 11.5 | 0.889 / 0.875 | 0.800 / 0.755 | 2 → 0.14 |
| 40,000 | 18.0 / 18.9 | 11.0 / 11.5 | 1.336 / 1.445 | 1.172 / 1.171 | 2 → 0.11 |

| in flight | CPU µs before | after | messages/s before | after | p50 ms before | after |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 41.4 / 38.7 | 35.1 / 35.8 | 4,500 / 4,815 | 4,729 / 4,823 | 0.204 / 0.198 | 0.195 / 0.196 |
| 8 | 24.8 / 27.1 | 19.9 / 18.5 | 25,865 / 21,524 | 25,176 / 25,492 | 0.302 / 0.321 | 0.305 / 0.297 |
| 64 | 17.8 / 18.4 | 11.3 / 12.6 | 50,194 / 51,049 | 72,256 / 54,022 | 1.201 / 1.211 | 0.868 / 1.067 |
| 256 | 16.4 / 18.4 | 10.5 / 10.3 | 58,627 / 54,508 | 91,969 / 93,047 | 4.214 / 4.578 | 2.706 / 2.678 |

## Where it belongs

In amqplib, whose loop does the writing — proposed there as [temich/amqplib#perf/one-write-per-turn](https://github.com/temich/amqplib/tree/perf/one-write-per-turn), where it is six lines and needs no wrapping of a socket the library does not own. Measured both ways at fixed rates and in flight: the two placements are indistinguishable, so this is a stopgap and goes when a release carries it upstream.

## Verification

- `npm test` — 547 tests, 33 suites
- `npm run features` — 85 scenarios, 660 steps, including `@heavy`
- the two Reply stream feature files, 4 further runs of 8 scenarios each, all passing

This PR was held as a draft because `Broker crashes while fetching a stream` failed under it — and, as it turned out, on `dev` as well: it asserted that a stream survives a broker crash, which is true only when the lost message happened to be on a shard that stayed up. #286 fixed the defect behind it and the scenario now states what is guaranteed. With that in, the suite gives a verdict on this change rather than a coin toss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)