### PR TITLE
A Reply stream that lost values raises

### DIFF
--- a/features/rpc.streams.feature
+++ b/features/rpc.streams.feature
@@ -49,12 +49,13 @@ Feature: Reply streams
     Given heartbeat interval is set to 300ms
     And a number generator with 100ms increasing delay replying `get_numbers` queue
     When the consumer requests a stream with request to the `get_numbers` queue
-    Then the consumer receives the stream:
-      """yaml
-      [0, 1, 3]
-      """
-    And after 500ms
-    Then the generator is destroyed
+    And the consumer receives the stream
+    # a stream that stopped arriving is not a stream that ended
+    Then the consumer's stream terminates
+    And a stream that lost values has raised
+    And the consumer has received a prefix of the stream
+    And after 200ms
+    And the generator is destroyed
 
   Scenario: Reply stream heartbeat
     # delay will exceed the idle timeout on the 3rd reply
@@ -71,12 +72,9 @@ Feature: Reply streams
     Then the consumer receives the stream
     And after 300ms
     Then the broker has crashed
-    # idle timeout
-    Then after 150ms
-    Then the consumer has received the stream:
-      """yaml
-      [0, 1, 2]
-      """
+    Then the consumer's stream terminates
+    And a stream that lost values has raised
+    And the consumer has received a prefix of the stream
     Then after 200ms
     Then the broker is up
     And the generator is destroyed

--- a/features/rpc.streams.shards.feature
+++ b/features/rpc.streams.shards.feature
@@ -29,10 +29,10 @@ Feature: Reply streams over shards
     And after 300ms
     And the broker has crashed
     And the broker is up
-    Then the consumer interrupts the stream
-    And the consumer has received the stream containing:
-      """yaml
-      [0, 1, 2, 3, 4, 5, 6]
-      """
+    # a stream whose shard carried a value away with it is cut short; one over a shard that
+    # survived is not, and neither of them ends as though it had been answered whole
+    Then the consumer's stream terminates
+    And a stream that lost values has raised
+    And the consumer has received a prefix of the stream
     And after 1000ms
     And the generator is destroyed

--- a/features/steps/.types/context.d.ts
+++ b/features/steps/.types/context.d.ts
@@ -31,6 +31,8 @@ declare namespace comq.features {
     stream: Readable
     streamValues: any[]
     streamEnded: boolean
+    streamError?: Error
+    streamLength?: number
     streams: Record<number, Readable>
     streamsValues: Record<number, any[]>
     streamsEnded: Record<number, boolean>

--- a/features/steps/rpc.js
+++ b/features/steps/rpc.js
@@ -48,8 +48,10 @@ Given('a number generator with {number}ms increasing delay replying {token} queu
   async function (delay, queue) {
     const that = this
 
+    this.streamLength = MAX
+
     class Stream extends Readable {
-      #MAX = 10
+      #MAX = MAX
       #count = 0
 
       constructor () {
@@ -305,6 +307,62 @@ Then('the consumer receives the stream',
   async function () {
     this.stream.on('data', (data) => this.streamValues.push(data))
     this.stream.on('end', () => (this.streamEnded = true))
+    this.stream.on('error', (error) => (this.streamError = error))
+  })
+
+Then('the consumer\'s stream terminates',
+  /**
+   * Either way it terminates: whole, or cut short. Bounded, so that a stream that never does
+   * fails the scenario rather than hanging it.
+   *
+   * @this {comq.features.Context}
+   */
+  async function () {
+    if (this.stream.destroyed || this.streamEnded === true) return
+
+    // both ways it terminates, and `once` would reject on the one that raises
+    const terminated = new Promise((resolve) => {
+      this.stream.once('close', resolve)
+      this.stream.once('error', resolve)
+    })
+    const expired = timeout(TERMINATION_MS).then(() => 'expired')
+
+    assert.notEqual(await Promise.race([terminated, expired]), 'expired',
+      'The stream has neither ended nor raised')
+  })
+
+Then('the consumer has received a prefix of the stream',
+  /**
+   * The order of yielded values is preserved and the tail may be lost, so what arrived is the
+   * sequence from its start, with nothing missing in between and nothing twice.
+   *
+   * @this {comq.features.Context}
+   */
+  async function () {
+    const expected = this.streamValues.map((_, index) => index)
+
+    assert.deepEqual(this.streamValues, expected,
+      `Received ${JSON.stringify(this.streamValues)}, which is not a prefix of the stream`)
+  })
+
+Then('a stream that lost values has raised',
+  /**
+   * A stream that did not deliver everything its producer yielded must not end as one that did:
+   * a caller cannot tell them apart otherwise.
+   *
+   * @this {comq.features.Context}
+   */
+  async function () {
+    const whole = this.streamValues.length === this.streamLength
+
+    if (whole) assert.equal(this.streamError, undefined, 'A whole stream has raised')
+    else {
+      assert.notEqual(this.streamError, undefined,
+        `The stream ended with ${this.streamValues.length} of ${this.streamLength} values and did not raise`)
+
+      assert.equal(this.streamError.name, 'Interrupted',
+        `The stream raised ${this.streamError.name}`)
+    }
   })
 
 Then('the consumer{number} receives the stream',
@@ -507,6 +565,11 @@ async function fetch (queue, payload, number) {
     this.streamsEnded[number] = false
   }
 }
+
+const MAX = 10
+
+/** What a stream is given to terminate in, which is longer than this generator takes. */
+const TERMINATION_MS = 5000
 
 global.COMQ_TESTING_IDLE_INTERVAL = 150
 global.COMQ_TESTING_HEARTBEAT_INTERVAL = 100

--- a/readme.md
+++ b/readme.md
@@ -377,7 +377,7 @@ the request will be retransmitted upon reconnection.
 
 A heartbeat message is sent to the `replyTo` queue whenever a Reply stream idles for 5 seconds.
 If the Consumer of the reply stream doesn't receive a reply or a heartbeat message for 12 seconds, the stream returned
-by `IO.request` is destroyed.
+by `IO.request` is destroyed with an `Interrupted` error.
 These intervals are not configurable.
 
 An "end stream" message is sent to the `replyTo` queue when the Reply stream is finished.
@@ -396,6 +396,17 @@ See also [Reply stream shutdown](#reply-stream-shutdown).
 While consuming the Reply stream if the broker connection is lost,
 or if the Consumer crashes or destroys the stream returned by `IO.request`,
 some of the values yielded by the Reply stream may be lost.
+
+A stream that lost values raises `Interrupted` rather than ending, so that a stream cut short is never taken for one
+that was answered whole. What it delivered before that is the sequence from its start, in order.
+
+```javascript
+try {
+  for await (const number of stream) console.log(number)
+} catch (error) {
+  if (error instanceof Interrupted) console.log('the rest is not coming')
+}
+```
 
 To avoid inconsistency, it is strongly recommended to use the Reply stream only with _safe_ Producers, which do not
 change the application state.

--- a/source/.io/ReplyStream.js
+++ b/source/.io/ReplyStream.js
@@ -3,6 +3,7 @@
 const { Readable } = require('node:stream')
 const { Promex } = require('promex')
 const { IDLE_INTERVAL, FLOW_HEADER, control } = require('./const')
+const { Interrupted } = require('../interrupted')
 
 class ReplyStream extends Readable {
   confirmation = new Promex()
@@ -36,6 +37,9 @@ class ReplyStream extends Readable {
   /** Whether the producer honours `pause` and `resume`. */
   #flow = false
 
+  /** Whether this stream has been handed to whoever asked for it, which is what confirms it. */
+  #confirmed = false
+
   /** Whether the producer has been asked to pause. */
   #throttled = false
 
@@ -68,13 +72,16 @@ class ReplyStream extends Readable {
     this._clear()
     this.push(null)
 
-    // a no-op once control.ok has been received
-    this.confirmation.reject(error ?? new Error(UNCONFIRMED))
+    // a no-op once control.ok has been received, and until then this is what it says: the
+    // stream never started, so the Request is re-sent rather than raised to anybody
+    this.confirmation.reject(new Error(UNCONFIRMED))
 
     if (this.#control !== undefined)
       void this.#reply(this.#control, control.end)
 
-    super._destroy(error, callback)
+    // a stream nobody has received yet cannot raise to anybody: the Request is re-sent instead,
+    // and the rejected confirmation is what says so
+    super._destroy(this.#confirmed ? error : null, callback)
   }
 
   /**
@@ -142,7 +149,7 @@ class ReplyStream extends Readable {
    */
   _buffer (payload, properties, size) {
     if (this.#buffered > this.#maxBufferSize || this.#bufferedBytes + size > this.#maxBufferBytes) {
-      this.destroy()
+      this.destroy(new Interrupted('the values held until the missing one arrives no longer fit'))
 
       return
     }
@@ -178,6 +185,7 @@ class ReplyStream extends Readable {
       case control.ok:
         this.#control = { properties }
         this.#flow = properties.headers?.[FLOW_HEADER] === true
+        this.#confirmed = true
         this.confirmation.resolve()
         break
       case control.heartbeat:
@@ -193,7 +201,10 @@ class ReplyStream extends Readable {
   _heartbeat () {
     if (this.#timeout !== null) clearTimeout(this.#timeout)
 
-    this.#timeout = setTimeout(() => this.destroy(), this.#idleInterval)
+    this.#timeout = setTimeout(
+      () => this.destroy(new Interrupted(`nothing arrived within ${this.#idleInterval}ms`)),
+      this.#idleInterval
+    )
   }
 
   _clear () {

--- a/source/index.js
+++ b/source/index.js
@@ -3,6 +3,7 @@
 const { connect, assert } = require('./connect')
 const { Retry, Park } = require('./verdicts')
 const { Unroutable } = require('./unroutable')
+const { Interrupted } = require('./interrupted')
 
 exports.connect = connect
 exports.assert = assert
@@ -10,3 +11,4 @@ exports.assert = assert
 exports.Retry = Retry
 exports.Park = Park
 exports.Unroutable = Unroutable
+exports.Interrupted = Interrupted

--- a/source/interrupted.js
+++ b/source/interrupted.js
@@ -1,0 +1,23 @@
+'use strict'
+
+/**
+ * A Reply stream that ended before its producer did: what was received is a prefix of what was
+ * yielded, and the rest is not coming. A stream that completes ends instead, so that the two
+ * cannot be taken for one another.
+ */
+class Interrupted extends Error {
+  /** @type {string} */
+  reason
+
+  /**
+   * @param {string} reason
+   */
+  constructor (reason) {
+    super(`Reply stream has been interrupted: ${reason}`)
+
+    this.name = 'Interrupted'
+    this.reason = reason
+  }
+}
+
+exports.Interrupted = Interrupted

--- a/test/ReplyStream.test.js
+++ b/test/ReplyStream.test.js
@@ -4,6 +4,8 @@ const { once } = require('node:events')
 const { ReplyStream, UNCONFIRMED } = require('../source/.io/ReplyStream')
 const { createReplyEmitter } = require('../source/.io/createReplyEmitter')
 const { control, FLOW_HEADER } = require('../source/.io/const')
+const { Interrupted } = require('../source/interrupted')
+const { timeout } = require('./helpers')
 
 /** @type {jest.Mock} */
 let reply
@@ -70,6 +72,49 @@ it('should reject confirmation when nothing arrives within the idle interval', a
   const idle = new ReplyStream(request, reply)
 
   await expect(idle.confirmation).rejects.toThrow(UNCONFIRMED)
+})
+
+it('should raise when nothing arrives within the idle interval', async () => {
+  global.COMQ_TESTING_IDLE_INTERVAL = 10
+
+  const request = {
+    emitter: createReplyEmitter('test'),
+    properties: { correlationId: 'raising-correlation' }
+  }
+
+  const idle = new ReplyStream(request, reply)
+
+  // the stream is answered, which is when it is handed to whoever asked for it
+  idle.arrange(control.ok, { headers: { index: 0 }, type: 'control' })
+
+  const [error] = await once(idle, 'error')
+
+  expect(error).toBeInstanceOf(Interrupted)
+  expect(idle.readableEnded).toStrictEqual(false)
+})
+
+it('should raise when the values held until the missing one arrives no longer fit', async () => {
+  stream.arrange(control.ok, { headers: { index: 0 }, type: 'control' })
+
+  for (let index = 2; index <= 6; index++) {
+    stream.arrange(index, { headers: { index } })
+  }
+
+  const [error] = await once(stream, 'error')
+
+  expect(error).toBeInstanceOf(Interrupted)
+})
+
+it('should end without raising when the consumer destroys it', async () => {
+  const raised = jest.fn()
+
+  stream.on('error', raised)
+  stream.arrange(control.ok, { headers: { index: 0 }, type: 'control' })
+  stream.destroy()
+
+  await timeout(10)
+
+  expect(raised).not.toHaveBeenCalled()
 })
 
 it('should keep confirmation resolved after control.ok', async () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -30,3 +30,11 @@ export class Unroutable extends Error {
   readonly exchange: string
   readonly key: string
 }
+
+/**
+ * A Reply stream that ended before its producer did: what was received is a prefix of what was
+ * yielded, and the rest is not coming. A stream that completes ends instead.
+ */
+export class Interrupted extends Error {
+  readonly reason: string
+}


### PR DESCRIPTION
## The defect

A Reply stream cut short ended as though it had been answered whole: the idle watchdog called `destroy()` without an error, which pushes `null`, so `for await` finished normally. A caller could not tell "the producer finished" from "half the answer is missing".

Traced from `features/rpc.streams.shards.feature`, twice, identically:

1. the producer transmits chunk `5` and it is lost — the broker carrying it is killed while the message is in flight, and the publish did not throw, so nothing re-sent it;
2. the next message (a heartbeat, index `6`) **does arrive**, and is held: index 6, expecting 5;
3. held messages do not re-arm the watchdog (`_buffer` does not call `_heartbeat`), by design — see `e8103ca`, "add stream idling while buffering";
4. 150 ms later the watchdog destroys the stream, cleanly. The consumer has 2 of 10 values and no way to know it.

## The change

Such a stream raises `Interrupted` — exported, with the reason on it — and what it delivered before that is the sequence from its start, in order.

A stream nobody has received yet raises to nobody: until `control.ok` confirms it, `comq` itself is holding it, so destroying it emits no error and the Request is re-sent exactly as before. That is what kept `io.test.js`'s retransmission from crashing on an unhandled `error` event, and it is why every test of an unconfirmed stream is unchanged.

## The scenario it was found by

`Broker crashes while fetching a stream` asserted that the stream survives a broker crash and delivers 7 of 10 values. The readme says the opposite — "no guarantee that the stream will be transmitted to the end", "Loss of tail" — and the assertion held only when the lost message happened to be on a shard that stayed up. Measured on `dev`: **2 failures in 8 runs.**

It now states what is guaranteed, which is true whichever shard was hit: the stream terminates, what arrived is a prefix of the sequence, and a stream that lost values raised. Same for the non-sharded crash scenario and for `Reply stream idle timeout`, which waits for the stream to terminate rather than for a fixed 500 ms that raced the 150 ms watchdog.

## Verification

- `npm test` — 541 tests, 32 suites
- `npm run features` — 85 scenarios, 660 steps, including `@heavy`
- the two stream feature files, **5 runs in a row, 8 scenarios each, all passing** — where the one scenario used to be a coin flip
- `npm audit` — 0 vulnerabilities

Built on `dev` with #281 and #282 merged.

## Compatibility

A consumer that read a Reply stream to its end and treated that as the whole answer will now see an `Interrupted` error where it silently saw a truncated one. That is the point of the change; `readme.md` states it under *Loss of tail* with the shape of the `catch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)