### PR TITLE
The lines husky deprecated are out of its hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 [ -n "$CI" ] && exit 0
+
 npm test


### PR DESCRIPTION
husky prints this on every commit, and says it will fail in v10:

```
husky - DEPRECATED
Please remove the following two lines from .husky/pre-commit
```

The hook still runs — this commit was made with it, 547 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)